### PR TITLE
fix: add support for server names 128 characters in length

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -23,6 +23,8 @@ http {
 	access_log /dev/stdout;
 	error_log stderr;
 
+	server_names_hash_bucket_size 128;
+
 	gzip on;
 
 	lua_shared_dict auto_ssl 2m;


### PR DESCRIPTION
Without this change, Dokku unit tests fail.