### PR TITLE
feat: increase logrotate time to 48 hours

### DIFF
--- a/bin/run-logrotate
+++ b/bin/run-logrotate
@@ -4,7 +4,7 @@ set -eo pipefail
 main() {
   while true; do
     logrotate --force /etc/logrotate.d/openresty
-    sleep 14400
+    sleep 172800
   done
 }
 


### PR DESCRIPTION
The default letsencrypt renewal check time is once every 24 hours, so this change helps fix an issue where reloading nginx would reset the renewal timer every 4 hours