### PR TITLE
feat: perform the ssl renewal check every 6 hours

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -34,9 +34,10 @@ http {
 	init_by_lua_block {
 		auto_ssl = (require "resty.auto-ssl").new()
 
-		-- Define a function to determine which SNI domains to automatically handle
-		-- and register new certificates for. Defaults to not allowing any domains,
-		-- so this must be configured.
+		-- perform ssl renewal check every 6 hours
+		auto_ssl:set("renew_check_interval", 21600)
+
+		-- Allow all domains to have letsencrypt provisioned by default
 		auto_ssl:set("allow_domain", function(domain)
 			return true
 		end)


### PR DESCRIPTION
This decrease works in conjunction with increasing the logrotate time to help ensure letsencrypt certificates are renewed.