### PR TITLE
feat: allow overriding whether or not a domain should have letsencrypt provisioned or not

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,23 +50,25 @@ RUN apt-get update && \
     apt-get -y --purge autoremove && \
     apt-get -y clean autoclean && \
     rm -rf \
-        /tmp/* \
-        /var/cache/apk/* \
-        /var/tmp/* \
-        /var/lib/apt/lists/* \
-        /var/log/alternatives.log \
-        /var/log/apt/ \
-        /var/log/bootstrap.log \
-        /var/log/btmp \
-        /var/log/dpkg.log \
-        /var/log/faillog \
-        /var/log/fsck/ \
-        /var/log/lastlog \
-        /var/log/wtmp \
-        /root/.cache \
+    /tmp/* \
+    /var/cache/apk/* \
+    /var/tmp/* \
+    /var/lib/apt/lists/* \
+    /var/log/alternatives.log \
+    /var/log/apt/ \
+    /var/log/bootstrap.log \
+    /var/log/btmp \
+    /var/log/dpkg.log \
+    /var/log/faillog \
+    /var/log/fsck/ \
+    /var/log/lastlog \
+    /var/log/wtmp \
+    /root/.cache \
     && \
+    mkdir -p /etc/nginx/lua && \
     find /var/cache/ ! -type d -exec rm '{}' \;
 
+COPY config/allow_domain.lua /etc/nginx/lua/allow_domain.lua
 COPY config/logrotate /etc/logrotate.d/openresty
 COPY config/init.d /etc/init.d/openresty
 COPY config/nginx.conf /etc/nginx/nginx.conf

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ When `true`, all requests to a domain where there is a port listener will be ign
 
 The default prefix to use when looking up labels. All examples below assume the default label prefix.
 
+#### `OPENRESTY_LETSENCRYPT_ALLOWED_DOMAINS_FUNC_BASE64`
+
+> default: `return true`
+
+The body of a function that returns whether or not the variable `domain` containing a domain name is allowed to have a letsencrypt ssl certificate provisioned.
+
 #### `OPENRESTY_LETSENCRYPT_EMAIL`
 
 > default: `` (none)

--- a/config.toml
+++ b/config.toml
@@ -25,3 +25,10 @@ dest = "/etc/resty-auto-ssl/letsencrypt/conf.d/custom.sh"
 watch = true
 wait = "500ms:2s"
 notifycmd = "/etc/init.d/openresty reload"
+
+[[config]]
+template = "/app/templates/allow_domain.lua.tmpl"
+dest = "/etc/nginx/lua/allow_domain.lua"
+watch = true
+wait = "500ms:2s"
+notifycmd = "/etc/init.d/openresty reload"

--- a/config/allow_domain.lua
+++ b/config/allow_domain.lua
@@ -1,0 +1,6 @@
+module('allow_domain', package.seeall)
+
+-- allowed is a function that returns true if the domain is allowed to have letsencrypt certificates issued
+function allowed(domain)
+    return true
+end

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -37,9 +37,11 @@ http {
 		-- perform ssl renewal check every 6 hours
 		auto_ssl:set("renew_check_interval", 21600)
 
-		-- Allow all domains to have letsencrypt provisioned by default
+		-- Allow certain domains to have letsencrypt provisioned by default
 		auto_ssl:set("allow_domain", function(domain)
-			return true
+			package.path = '/etc/nginx/lua/?.lua;' .. package.path
+			local allow_domain = require("allow_domain")
+			return allow_domain.allowed(domain)
 		end)
 
 		auto_ssl:init()

--- a/templates/allow_domain.lua.tmpl
+++ b/templates/allow_domain.lua.tmpl
@@ -1,0 +1,7 @@
+module('allow_domain', package.seeall)
+
+-- allowed is a function that returns true if the domain is allowed to have letsencrypt certificates issued
+function allowed(domain)
+{{- $default_allowed := b64enc ("return true") }}
+{{ indent 4 (b64dec (default $default_allowed (env "OPENRESTY_LETSENCRYPT_ALLOWED_DOMAINS_FUNC_BASE64"))) }}
+end


### PR DESCRIPTION
Previously this allowed all domains, which can be spammy if anyone uses a catchall server_name. This change allows folks to constrain that by providing the body of a lua function to determine if a domain is allowed to have ssl provisioned or not.

Closes #65