### PR TITLE
fix: chown the entire resty-auto-ssl directory

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -14,6 +14,7 @@ main() {
 
   mkdir -p /etc/resty-auto-ssl/storage
   chown www-data:www-data /etc/resty-auto-ssl/storage
+  chown -R www-data:www-data /etc/resty-auto-ssl
 
   echo "====> Starting"
   exec "$@"


### PR DESCRIPTION
Without this, permissions for files would be incorrect, causing issues on renewing certificates.