### PR TITLE
feat: add basic auth support via openresty.basic-auth label

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,24 @@ on:
       - 'main'
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+
+      - name: Build image
+        run: docker image build -t openresty-docker-proxy:latest .
+
+      - name: Pull test image
+        run: docker image pull --platform linux/amd64 dokku/python-sample
+
+      - name: Run tests
+        run: bats test.bats
+
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,8 @@ RUN apt-get update && \
     find /var/cache/ ! -type d -exec rm '{}' \;
 
 COPY config/allow_domain.lua /etc/nginx/lua/allow_domain.lua
+COPY config/basic_auth.lua /etc/nginx/lua/basic_auth.lua
+COPY config/test_basic_auth.lua /etc/nginx/lua/test_basic_auth.lua
 COPY config/logrotate /etc/logrotate.d/openresty
 COPY config/init.d /etc/init.d/openresty
 COPY config/nginx.conf /etc/nginx/nginx.conf
@@ -83,4 +85,4 @@ WORKDIR /app
 CMD ["forego", "start", "-r"]
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
-ENV DOCKER_HOST unix:///var/run/docker.sock
+ENV DOCKER_HOST=unix:///var/run/docker.sock

--- a/README.md
+++ b/README.md
@@ -78,6 +78,31 @@ The default os page size to base default proxy values on.
 
 The format of the openresty access log for the app.
 
+#### `openresty.basic-auth`
+
+Enables HTTP Basic Authentication on the app's location block. The value is a space-separated list of `user:password_hash` entries.
+
+Supported password hash formats:
+
+- `{SHA}base64hash` - SHA-1 hash encoded in base64 (recommended)
+- Plain text password (not recommended for production)
+
+Generate a SHA-1 hash for a password:
+
+```bash
+echo -n "mypassword" | openssl sha1 -binary | openssl base64
+```
+
+Example usage:
+
+```bash
+# Single user
+docker run --label='openresty.basic-auth=myuser:{SHA}kd/Z3bQZiv/FwZTNjObTOP3kcOI=' myimage
+
+# Multiple users
+docker run --label='openresty.basic-auth=user1:{SHA}hash1 user2:{SHA}hash2' myimage
+```
+
 #### `openresty.access-log-path`
 
 The path - in the container - where the access logs will be written.

--- a/config/basic_auth.lua
+++ b/config/basic_auth.lua
@@ -1,0 +1,76 @@
+local _M = {}
+
+local bit = require("bit")
+
+-- constant_time_compare compares two strings in constant time
+-- to prevent timing attacks from leaking hash prefix information
+local function constant_time_compare(a, b)
+    if #a ~= #b then
+        return false
+    end
+
+    local result = 0
+    for i = 1, #a do
+        result = bit.bor(result, bit.bxor(string.byte(a, i), string.byte(b, i)))
+    end
+
+    return result == 0
+end
+
+-- check verifies HTTP Basic Authentication credentials against
+-- a space-separated string of user:password_hash entries.
+--
+-- Supported password hash formats:
+--   {SHA}base64hash - SHA-1 hash encoded in base64
+--   plaintext       - plain text password (not recommended)
+function _M.check(auth_entries_str)
+    local header = ngx.var.http_authorization
+    if not header then
+        ngx.header["WWW-Authenticate"] = 'Basic realm="Restricted"'
+        ngx.exit(ngx.HTTP_UNAUTHORIZED)
+        return
+    end
+
+    local encoded = header:match("^Basic%s+(.+)$")
+    if not encoded then
+        ngx.header["WWW-Authenticate"] = 'Basic realm="Restricted"'
+        ngx.exit(ngx.HTTP_UNAUTHORIZED)
+        return
+    end
+
+    local decoded = ngx.decode_base64(encoded)
+    if not decoded then
+        ngx.header["WWW-Authenticate"] = 'Basic realm="Restricted"'
+        ngx.exit(ngx.HTTP_UNAUTHORIZED)
+        return
+    end
+
+    local provided_user, provided_pass = decoded:match("^([^:]+):(.+)$")
+    if not provided_user or not provided_pass then
+        ngx.header["WWW-Authenticate"] = 'Basic realm="Restricted"'
+        ngx.exit(ngx.HTTP_UNAUTHORIZED)
+        return
+    end
+
+    for entry in auth_entries_str:gmatch("%S+") do
+        local user, stored_hash = entry:match("^([^:]+):(.+)$")
+        if user and stored_hash and user == provided_user then
+            local sha_hash = stored_hash:match("^{SHA}(.+)$")
+            if sha_hash then
+                local computed = ngx.encode_base64(ngx.sha1_bin(provided_pass))
+                if constant_time_compare(computed, sha_hash) then
+                    return
+                end
+            else
+                if constant_time_compare(stored_hash, provided_pass) then
+                    return
+                end
+            end
+        end
+    end
+
+    ngx.header["WWW-Authenticate"] = 'Basic realm="Restricted"'
+    ngx.exit(ngx.HTTP_UNAUTHORIZED)
+end
+
+return _M

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -27,6 +27,8 @@ http {
 
 	gzip on;
 
+	lua_package_path '/etc/nginx/lua/?.lua;;';
+
 	lua_shared_dict auto_ssl 2m;
 	lua_shared_dict auto_ssl_settings 64k;
 	resolver 8.8.8.8;
@@ -39,7 +41,6 @@ http {
 
 		-- Allow certain domains to have letsencrypt provisioned by default
 		auto_ssl:set("allow_domain", function(domain)
-			package.path = '/etc/nginx/lua/?.lua;' .. package.path
 			local allow_domain = require("allow_domain")
 			return allow_domain.allowed(domain)
 		end)

--- a/config/test_basic_auth.lua
+++ b/config/test_basic_auth.lua
@@ -1,0 +1,202 @@
+-- Unit tests for basic_auth module
+-- Run with: resty -I /etc/nginx/lua /etc/nginx/lua/test_basic_auth.lua
+
+local test_count = 0
+local pass_count = 0
+
+local function test(name, fn)
+    test_count = test_count + 1
+    local ok, err = pcall(fn)
+    if ok then
+        pass_count = pass_count + 1
+        print("PASS: " .. name)
+    else
+        print("FAIL: " .. name .. " - " .. tostring(err))
+    end
+end
+
+local function assert_eq(expected, actual, msg)
+    if expected ~= actual then
+        error((msg or "") .. " expected: " .. tostring(expected) .. ", got: " .. tostring(actual))
+    end
+end
+
+-- Save real ngx functions
+local real_exit = ngx.exit
+local real_encode_base64 = ngx.encode_base64
+local real_decode_base64 = ngx.decode_base64
+local real_sha1_bin = ngx.sha1_bin
+
+-- Mock state
+local mock_exit_code = nil
+local mock_headers = {}
+
+-- Override ngx.exit to capture exit code instead of actually exiting
+ngx.exit = function(code)
+    mock_exit_code = code
+    error("ngx.exit:" .. code)
+end
+
+-- Override ngx.header to capture headers
+ngx.header = setmetatable({}, {
+    __newindex = function(_, k, v)
+        mock_headers[k] = v
+    end,
+    __index = function(_, k)
+        return mock_headers[k]
+    end,
+})
+
+-- Ensure ngx.var exists
+if not ngx.var then
+    ngx.var = {}
+end
+
+-- Reset mocks before each test
+local function reset_mocks()
+    mock_exit_code = nil
+    mock_headers = {}
+    ngx.var = {}
+    ngx.header = setmetatable({}, {
+        __newindex = function(_, k, v)
+            mock_headers[k] = v
+        end,
+        __index = function(_, k)
+            return mock_headers[k]
+        end,
+    })
+end
+
+-- Helper: encode credentials to Basic auth header value
+local function basic_auth_header(user, pass)
+    return "Basic " .. ngx.encode_base64(user .. ":" .. pass)
+end
+
+-- Load the module
+package.loaded['basic_auth'] = nil
+local basic_auth = require("basic_auth")
+
+-- SHA-1 of "password" = W6ph5Mm5Pz8GgiULbPgzG37mj9g=
+local sha_password = "{SHA}" .. ngx.encode_base64(ngx.sha1_bin("password"))
+
+-- Tests
+
+test("SHA-1: valid credentials pass", function()
+    reset_mocks()
+    ngx.var.http_authorization = basic_auth_header("testuser", "password")
+    basic_auth.check("testuser:" .. sha_password)
+    -- If we get here without error, auth passed
+end)
+
+test("SHA-1: wrong password returns 401", function()
+    reset_mocks()
+    ngx.var.http_authorization = basic_auth_header("testuser", "wrongpass")
+    local ok, err = pcall(basic_auth.check, "testuser:" .. sha_password)
+    assert_eq(false, ok, "should have called ngx.exit")
+    assert_eq(401, mock_exit_code, "should return 401")
+    assert_eq('Basic realm="Restricted"', mock_headers["WWW-Authenticate"], "should set WWW-Authenticate")
+end)
+
+test("Plain text: valid credentials pass", function()
+    reset_mocks()
+    ngx.var.http_authorization = basic_auth_header("admin", "secret123")
+    basic_auth.check("admin:secret123")
+end)
+
+test("Plain text: wrong password returns 401", function()
+    reset_mocks()
+    ngx.var.http_authorization = basic_auth_header("admin", "wrong")
+    local ok, err = pcall(basic_auth.check, "admin:secret123")
+    assert_eq(false, ok, "should have called ngx.exit")
+    assert_eq(401, mock_exit_code, "should return 401")
+end)
+
+test("Missing Authorization header returns 401", function()
+    reset_mocks()
+    ngx.var.http_authorization = nil
+    local ok, err = pcall(basic_auth.check, "testuser:" .. sha_password)
+    assert_eq(false, ok, "should have called ngx.exit")
+    assert_eq(401, mock_exit_code, "should return 401")
+    assert_eq('Basic realm="Restricted"', mock_headers["WWW-Authenticate"], "should set WWW-Authenticate")
+end)
+
+test("Non-Basic Authorization header returns 401", function()
+    reset_mocks()
+    ngx.var.http_authorization = "Bearer some-token"
+    local ok, err = pcall(basic_auth.check, "testuser:" .. sha_password)
+    assert_eq(false, ok, "should have called ngx.exit")
+    assert_eq(401, mock_exit_code, "should return 401")
+end)
+
+test("Invalid Base64 in Authorization header returns 401", function()
+    reset_mocks()
+    ngx.var.http_authorization = "Basic !!!invalid!!!"
+    local ok, err = pcall(basic_auth.check, "testuser:" .. sha_password)
+    assert_eq(false, ok, "should have called ngx.exit")
+    assert_eq(401, mock_exit_code, "should return 401")
+end)
+
+test("Unknown user returns 401", function()
+    reset_mocks()
+    ngx.var.http_authorization = basic_auth_header("unknown", "password")
+    local ok, err = pcall(basic_auth.check, "testuser:" .. sha_password)
+    assert_eq(false, ok, "should have called ngx.exit")
+    assert_eq(401, mock_exit_code, "should return 401")
+end)
+
+test("Multiple users: first user authenticates", function()
+    reset_mocks()
+    local sha_secret = "{SHA}" .. ngx.encode_base64(ngx.sha1_bin("secret"))
+    ngx.var.http_authorization = basic_auth_header("user1", "password")
+    basic_auth.check("user1:" .. sha_password .. " user2:" .. sha_secret)
+end)
+
+test("Multiple users: second user authenticates", function()
+    reset_mocks()
+    local sha_secret = "{SHA}" .. ngx.encode_base64(ngx.sha1_bin("secret"))
+    ngx.var.http_authorization = basic_auth_header("user2", "secret")
+    basic_auth.check("user1:" .. sha_password .. " user2:" .. sha_secret)
+end)
+
+test("Multiple users: wrong password for matched user returns 401", function()
+    reset_mocks()
+    local sha_secret = "{SHA}" .. ngx.encode_base64(ngx.sha1_bin("secret"))
+    ngx.var.http_authorization = basic_auth_header("user1", "wrong")
+    local ok, err = pcall(basic_auth.check, "user1:" .. sha_password .. " user2:" .. sha_secret)
+    assert_eq(false, ok, "should have called ngx.exit")
+    assert_eq(401, mock_exit_code, "should return 401")
+end)
+
+test("Empty auth string returns 401", function()
+    reset_mocks()
+    ngx.var.http_authorization = basic_auth_header("testuser", "password")
+    local ok, err = pcall(basic_auth.check, "")
+    assert_eq(false, ok, "should have called ngx.exit")
+    assert_eq(401, mock_exit_code, "should return 401")
+end)
+
+test("Malformed entry (no colon) is skipped, returns 401", function()
+    reset_mocks()
+    ngx.var.http_authorization = basic_auth_header("testuser", "password")
+    local ok, err = pcall(basic_auth.check, "malformed-entry")
+    assert_eq(false, ok, "should have called ngx.exit")
+    assert_eq(401, mock_exit_code, "should return 401")
+end)
+
+test("Credentials without password part returns 401", function()
+    reset_mocks()
+    ngx.var.http_authorization = "Basic " .. ngx.encode_base64("useronly")
+    local ok, err = pcall(basic_auth.check, "testuser:" .. sha_password)
+    assert_eq(false, ok, "should have called ngx.exit")
+    assert_eq(401, mock_exit_code, "should return 401")
+end)
+
+-- Summary
+print("")
+print(string.format("Results: %d/%d tests passed", pass_count, test_count))
+if pass_count ~= test_count then
+    print("FAILED")
+    os.exit(1)
+else
+    print("OK")
+end

--- a/fixtures/http-basic-auth.tmpl
+++ b/fixtures/http-basic-auth.tmpl
@@ -1,0 +1,71 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS:5000;
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location / {
+        access_by_lua_block {
+            local basic_auth = require("basic_auth")
+            basic_auth.check([===[testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=]===])
+        }
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen      80 default_server;
+    access_log  /var/log/nginx/default-server-80-access.log;
+    error_log   /var/log/nginx/default-server-80-error.log;
+    return      404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    access_log          /var/log/nginx/default-server-443-access.log;
+    error_log           /var/log/nginx/default-server-443-error.log;
+    return              404;
+}

--- a/templates/http.conf.tmpl
+++ b/templates/http.conf.tmpl
@@ -72,6 +72,7 @@ upstream {{ $app }}-{{ $process_type }}-{{ $container_port }} {
 {{ $openresty_domains :=                 when (contains $first_container.Labels (printf "%s%s" $label_prefix "domains"))                 (index $first_container.Labels (printf "%s%s" $label_prefix "domains")) "" }}
 {{ $openresty_domains_list := splitList " " $openresty_domains }}
 {{ $openresty_https_port :=              when (contains $first_container.Labels (printf "%s%s" $label_prefix "https-port"))              (index $first_container.Labels (printf "%s%s" $label_prefix "https-port")) "443" }}
+{{ $openresty_basic_auth :=              when (contains $first_container.Labels (printf "%s%s" $label_prefix "basic-auth"))              (index $first_container.Labels (printf "%s%s" $label_prefix "basic-auth")) "" }}
 {{ $openresty_letsencrypt :=             when (contains $first_container.Labels (printf "%s%s" $label_prefix "letsencrypt"))             (index $first_container.Labels (printf "%s%s" $label_prefix "letsencrypt")) "" }}
 {{ $openresty_letsencrypt_enabled := eq $openresty_letsencrypt "true" }}
 {{ $openresty_has_cert := exists (printf "/etc/nginx/ssl/%s-server.key" $app) }}
@@ -138,6 +139,12 @@ server {
 
     {{ else }}
     location / {
+        {{ if $openresty_basic_auth }}
+        access_by_lua_block {
+            local basic_auth = require("basic_auth")
+            basic_auth.check([===[{{ $openresty_basic_auth }}]===])
+        }
+        {{ end }}
         gzip                    on;
         gzip_buffers            4 32k;
         gzip_comp_level         6;

--- a/test.bats
+++ b/test.bats
@@ -94,7 +94,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker exec -it openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -147,7 +147,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker exec -it openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -183,7 +183,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker exec -it openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -219,7 +219,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker exec -it openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -255,7 +255,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker exec -it openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -275,7 +275,7 @@ teardown() {
 
   sleep 3
 
-  run docker exec -it openresty-docker-proxy resty -I /etc/nginx/lua /etc/nginx/lua/test_basic_auth.lua
+  run docker exec openresty-docker-proxy resty -I /etc/nginx/lua /etc/nginx/lua/test_basic_auth.lua
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -312,7 +312,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker exec -it openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -365,7 +365,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker exec -it openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -401,7 +401,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker exec -it openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -420,7 +420,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker exec -it openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/test.bats
+++ b/test.bats
@@ -226,6 +226,61 @@ teardown() {
   assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/http.tmpl)"
 }
 
+@test "[start] http basic-auth" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  run echo "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec -it openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/http-basic-auth.tmpl)"
+}
+
+@test "[unit] basic-auth lua module" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker exec -it openresty-docker-proxy resty -I /etc/nginx/lua /etc/nginx/lua/test_basic_auth.lua
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
 @test "[start] http-include" {
   run docker image build -t openresty-docker-proxy:latest .
   echo "output: $output"


### PR DESCRIPTION
## Summary

- Adds `openresty.basic-auth` label for HTTP Basic Authentication on app location blocks
- Implements Lua-based credential verification with `{SHA}` (SHA-1 base64) and plain text support
- Uses constant-time string comparison to prevent timing attacks
- Adds `lua_package_path` directive to `nginx.conf` for proper Lua module resolution
- Adds CI test job to run bats tests on PRs and pushes to main
- Includes 14 Lua unit tests covering auth verification, credential parsing, and error handling
- Fixes Dockerfile `ENV` syntax warning (LegacyKeyValueFormat)

Closes #45