### PR TITLE
Add IP-based access control via openresty.allowed-ips label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,9 @@ RUN apt-get update && \
     find /var/cache/ ! -type d -exec rm '{}' \;
 
 COPY config/allow_domain.lua /etc/nginx/lua/allow_domain.lua
+COPY config/allowed_ips.lua /etc/nginx/lua/allowed_ips.lua
 COPY config/basic_auth.lua /etc/nginx/lua/basic_auth.lua
+COPY config/test_allowed_ips.lua /etc/nginx/lua/test_allowed_ips.lua
 COPY config/test_basic_auth.lua /etc/nginx/lua/test_basic_auth.lua
 COPY config/logrotate /etc/logrotate.d/openresty
 COPY config/init.d /etc/init.d/openresty

--- a/README.md
+++ b/README.md
@@ -78,6 +78,39 @@ The default os page size to base default proxy values on.
 
 The format of the openresty access log for the app.
 
+#### `openresty.access-satisfy`
+
+> default: `all`
+
+Controls how IP restriction (`allowed-ips`) interacts with HTTP Basic Authentication (`basic-auth`) when both are set. Possible values:
+
+- `all` (default): Both IP restriction AND basic auth must pass.
+- `any`: Either a matching IP OR valid basic auth credentials will grant access.
+
+This label only takes effect when both `openresty.allowed-ips` and `openresty.basic-auth` are set.
+
+#### `openresty.allowed-ips`
+
+Restricts access to the app based on client IP address. The value is a space-separated list of IPv4 addresses and CIDR ranges. Requests from non-matching IPs receive a `403 Forbidden` response.
+
+Only IPv4 addresses and CIDR ranges are currently supported. The client IP is determined by `remote_addr`, which is the direct connecting client's IP address. If this proxy runs behind another load balancer, configure `set_real_ip_from` via an include label.
+
+Example usage:
+
+```bash
+# Allow only specific IPs
+docker run --label='openresty.allowed-ips=10.0.0.0/8 192.168.1.100' myimage
+
+# Allow specific IPs AND require basic auth (satisfy all, the default)
+docker run --label='openresty.allowed-ips=10.0.0.0/8' \
+           --label='openresty.basic-auth=myuser:{SHA}hash' myimage
+
+# Allow specific IPs OR basic auth (satisfy any)
+docker run --label='openresty.allowed-ips=10.0.0.0/8' \
+           --label='openresty.basic-auth=myuser:{SHA}hash' \
+           --label='openresty.access-satisfy=any' myimage
+```
+
 #### `openresty.basic-auth`
 
 Enables HTTP Basic Authentication on the app's location block. The value is a space-separated list of `user:password_hash` entries.

--- a/config/allowed_ips.lua
+++ b/config/allowed_ips.lua
@@ -1,0 +1,73 @@
+local _M = {}
+
+local bit = require("bit")
+
+-- parse_ipv4 converts a dotted-decimal IPv4 string to a 32-bit number.
+-- Returns nil if the string is not a valid IPv4 address.
+local function parse_ipv4(ip_str)
+    local o1, o2, o3, o4 = ip_str:match("^(%d+)%.(%d+)%.(%d+)%.(%d+)$")
+    if not o1 then
+        return nil
+    end
+
+    o1, o2, o3, o4 = tonumber(o1), tonumber(o2), tonumber(o3), tonumber(o4)
+    if o1 > 255 or o2 > 255 or o3 > 255 or o4 > 255 then
+        return nil
+    end
+
+    return bit.tobit(o1 * 16777216 + o2 * 65536 + o3 * 256 + o4)
+end
+
+-- cidr_mask builds a 32-bit subnet mask for a given prefix length (0-32).
+local function cidr_mask(prefix_len)
+    if prefix_len == 0 then
+        return bit.tobit(0)
+    end
+
+    return bit.lshift(-1, 32 - prefix_len)
+end
+
+-- is_allowed checks whether ngx.var.remote_addr matches any entry
+-- in the space-separated allowed_ips_str. Each entry is either a
+-- plain IPv4 address (treated as /32) or a CIDR like 10.0.0.0/8.
+-- Returns true if the IP matches any entry, false otherwise.
+function _M.is_allowed(allowed_ips_str)
+    local remote_addr = ngx.var.remote_addr
+    if not remote_addr then
+        return false
+    end
+
+    local client_ip = parse_ipv4(remote_addr)
+    if not client_ip then
+        return false
+    end
+
+    for entry in allowed_ips_str:gmatch("%S+") do
+        local ip_part, prefix_str = entry:match("^(.+)/(%d+)$")
+        if not ip_part then
+            ip_part = entry
+            prefix_str = "32"
+        end
+
+        local net_ip = parse_ipv4(ip_part)
+        local prefix_len = tonumber(prefix_str)
+        if net_ip and prefix_len and prefix_len >= 0 and prefix_len <= 32 then
+            local mask = cidr_mask(prefix_len)
+            if bit.band(client_ip, mask) == bit.band(net_ip, mask) then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+-- check denies the request with 403 Forbidden if the client IP
+-- does not match any entry in allowed_ips_str.
+function _M.check(allowed_ips_str)
+    if not _M.is_allowed(allowed_ips_str) then
+        ngx.exit(ngx.HTTP_FORBIDDEN)
+    end
+end
+
+return _M

--- a/config/test_allowed_ips.lua
+++ b/config/test_allowed_ips.lua
@@ -1,0 +1,217 @@
+-- Unit tests for allowed_ips module
+-- Run with: resty -I /etc/nginx/lua /etc/nginx/lua/test_allowed_ips.lua
+
+local test_count = 0
+local pass_count = 0
+
+local function test(name, fn)
+    test_count = test_count + 1
+    local ok, err = pcall(fn)
+    if ok then
+        pass_count = pass_count + 1
+        print("PASS: " .. name)
+    else
+        print("FAIL: " .. name .. " - " .. tostring(err))
+    end
+end
+
+local function assert_eq(expected, actual, msg)
+    if expected ~= actual then
+        error((msg or "") .. " expected: " .. tostring(expected) .. ", got: " .. tostring(actual))
+    end
+end
+
+-- Mock state
+local mock_exit_code = nil
+
+-- Override ngx.exit to capture exit code instead of actually exiting
+ngx.exit = function(code)
+    mock_exit_code = code
+    error("ngx.exit:" .. code)
+end
+
+-- Ensure ngx.var exists
+if not ngx.var then
+    ngx.var = {}
+end
+
+-- Reset mocks before each test
+local function reset_mocks()
+    mock_exit_code = nil
+    ngx.var = {}
+end
+
+-- Load the module
+package.loaded['allowed_ips'] = nil
+local allowed_ips = require("allowed_ips")
+
+-- Tests
+
+test("Single IP: exact match returns true", function()
+    reset_mocks()
+    ngx.var.remote_addr = "192.168.1.100"
+    assert_eq(true, allowed_ips.is_allowed("192.168.1.100"), "should match exact IP")
+end)
+
+test("Single IP: no match returns false", function()
+    reset_mocks()
+    ngx.var.remote_addr = "192.168.1.101"
+    assert_eq(false, allowed_ips.is_allowed("192.168.1.100"), "should not match different IP")
+end)
+
+test("CIDR /24: match within range", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.42"
+    assert_eq(true, allowed_ips.is_allowed("10.0.0.0/24"), "should match IP in /24 range")
+end)
+
+test("CIDR /24: no match outside range", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.1.1"
+    assert_eq(false, allowed_ips.is_allowed("10.0.0.0/24"), "should not match IP outside /24 range")
+end)
+
+test("CIDR /8: match within large range", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.255.255.255"
+    assert_eq(true, allowed_ips.is_allowed("10.0.0.0/8"), "should match IP in /8 range")
+end)
+
+test("CIDR /8: no match outside range", function()
+    reset_mocks()
+    ngx.var.remote_addr = "11.0.0.1"
+    assert_eq(false, allowed_ips.is_allowed("10.0.0.0/8"), "should not match IP outside /8 range")
+end)
+
+test("CIDR /32: exact match only", function()
+    reset_mocks()
+    ngx.var.remote_addr = "192.168.1.1"
+    assert_eq(true, allowed_ips.is_allowed("192.168.1.1/32"), "should match exact IP with /32")
+end)
+
+test("CIDR /32: no match for different IP", function()
+    reset_mocks()
+    ngx.var.remote_addr = "192.168.1.2"
+    assert_eq(false, allowed_ips.is_allowed("192.168.1.1/32"), "should not match different IP with /32")
+end)
+
+test("CIDR /0: matches everything", function()
+    reset_mocks()
+    ngx.var.remote_addr = "123.45.67.89"
+    assert_eq(true, allowed_ips.is_allowed("0.0.0.0/0"), "should match any IP with /0")
+end)
+
+test("Multiple entries: match on second entry", function()
+    reset_mocks()
+    ngx.var.remote_addr = "172.16.0.5"
+    assert_eq(true, allowed_ips.is_allowed("10.0.0.0/8 172.16.0.0/12"), "should match second CIDR entry")
+end)
+
+test("Multiple entries: no match on any", function()
+    reset_mocks()
+    ngx.var.remote_addr = "8.8.8.8"
+    assert_eq(false, allowed_ips.is_allowed("10.0.0.0/8 172.16.0.0/12 192.168.0.0/16"), "should not match any entry")
+end)
+
+test("Mixed entries: plain IP and CIDR", function()
+    reset_mocks()
+    ngx.var.remote_addr = "1.2.3.4"
+    assert_eq(true, allowed_ips.is_allowed("10.0.0.0/8 1.2.3.4"), "should match plain IP in mixed list")
+end)
+
+test("IPv6 remote_addr returns false", function()
+    reset_mocks()
+    ngx.var.remote_addr = "::1"
+    assert_eq(false, allowed_ips.is_allowed("127.0.0.1"), "IPv6 address should not match IPv4 entries")
+end)
+
+test("IPv6 remote_addr returns false with CIDR", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db8::1"
+    assert_eq(false, allowed_ips.is_allowed("0.0.0.0/0"), "IPv6 address should not match even /0")
+end)
+
+test("Missing remote_addr returns false", function()
+    reset_mocks()
+    ngx.var.remote_addr = nil
+    assert_eq(false, allowed_ips.is_allowed("10.0.0.0/8"), "nil remote_addr should return false")
+end)
+
+test("Malformed entry is skipped, valid entry still matches", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.1"
+    assert_eq(true, allowed_ips.is_allowed("not-an-ip 10.0.0.0/8"), "should skip malformed and match valid")
+end)
+
+test("Malformed entry only, no match", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.1"
+    assert_eq(false, allowed_ips.is_allowed("not-an-ip bad/entry"), "all malformed should return false")
+end)
+
+test("Empty string returns false", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.1"
+    assert_eq(false, allowed_ips.is_allowed(""), "empty string should return false")
+end)
+
+test("Invalid prefix length is skipped", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.1"
+    assert_eq(false, allowed_ips.is_allowed("10.0.0.0/33"), "prefix > 32 should be skipped")
+end)
+
+test("Edge case: 255.255.255.255 exact match", function()
+    reset_mocks()
+    ngx.var.remote_addr = "255.255.255.255"
+    assert_eq(true, allowed_ips.is_allowed("255.255.255.255"), "should match 255.255.255.255")
+end)
+
+test("Edge case: 0.0.0.0 exact match", function()
+    reset_mocks()
+    ngx.var.remote_addr = "0.0.0.0"
+    assert_eq(true, allowed_ips.is_allowed("0.0.0.0"), "should match 0.0.0.0")
+end)
+
+test("Edge case: octet out of range is skipped", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.1"
+    assert_eq(false, allowed_ips.is_allowed("256.0.0.0/8"), "octet > 255 should be skipped")
+end)
+
+test("check: does not exit when IP matches", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.1"
+    allowed_ips.check("10.0.0.0/8")
+    -- If we get here without error, check passed
+end)
+
+test("check: exits 403 when IP does not match", function()
+    reset_mocks()
+    ngx.var.remote_addr = "192.168.1.1"
+    local ok, err = pcall(allowed_ips.check, "10.0.0.0/8")
+    assert_eq(false, ok, "should have called ngx.exit")
+    assert_eq(403, mock_exit_code, "should return 403")
+end)
+
+test("CIDR /16: match within range", function()
+    reset_mocks()
+    ngx.var.remote_addr = "192.168.50.1"
+    assert_eq(true, allowed_ips.is_allowed("192.168.0.0/16"), "should match IP in /16 range")
+end)
+
+test("Loopback: 127.0.0.1 match", function()
+    reset_mocks()
+    ngx.var.remote_addr = "127.0.0.1"
+    assert_eq(true, allowed_ips.is_allowed("127.0.0.1"), "should match loopback")
+end)
+
+-- Summary
+print("")
+print(string.format("Results: %d/%d tests passed", pass_count, test_count))
+if pass_count ~= test_count then
+    print("FAILED")
+    os.exit(1)
+else
+    print("OK")
+end

--- a/fixtures/http-allowed-ips-basic-auth-satisfy-any.tmpl
+++ b/fixtures/http-allowed-ips-basic-auth-satisfy-any.tmpl
@@ -1,0 +1,74 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS:5000;
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location / {
+        access_by_lua_block {
+            local allowed_ips = require("allowed_ips")
+            if not allowed_ips.is_allowed([===[10.0.0.0/8 192.168.1.100]===]) then
+                local basic_auth = require("basic_auth")
+                basic_auth.check([===[testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=]===])
+            end
+        }
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen      80 default_server;
+    access_log  /var/log/nginx/default-server-80-access.log;
+    error_log   /var/log/nginx/default-server-80-error.log;
+    return      404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    access_log          /var/log/nginx/default-server-443-access.log;
+    error_log           /var/log/nginx/default-server-443-error.log;
+    return              404;
+}

--- a/fixtures/http-allowed-ips-basic-auth.tmpl
+++ b/fixtures/http-allowed-ips-basic-auth.tmpl
@@ -1,0 +1,73 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS:5000;
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location / {
+        access_by_lua_block {
+            local allowed_ips = require("allowed_ips")
+            allowed_ips.check([===[10.0.0.0/8 192.168.1.100]===])
+            local basic_auth = require("basic_auth")
+            basic_auth.check([===[testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=]===])
+        }
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen      80 default_server;
+    access_log  /var/log/nginx/default-server-80-access.log;
+    error_log   /var/log/nginx/default-server-80-error.log;
+    return      404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    access_log          /var/log/nginx/default-server-443-access.log;
+    error_log           /var/log/nginx/default-server-443-error.log;
+    return              404;
+}

--- a/fixtures/http-allowed-ips.tmpl
+++ b/fixtures/http-allowed-ips.tmpl
@@ -1,0 +1,71 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS:5000;
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location / {
+        access_by_lua_block {
+            local allowed_ips = require("allowed_ips")
+            allowed_ips.check([===[10.0.0.0/8 192.168.1.100]===])
+        }
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen      80 default_server;
+    access_log  /var/log/nginx/default-server-80-access.log;
+    error_log   /var/log/nginx/default-server-80-error.log;
+    return      404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    access_log          /var/log/nginx/default-server-443-access.log;
+    error_log           /var/log/nginx/default-server-443-error.log;
+    return              404;
+}

--- a/templates/http.conf.tmpl
+++ b/templates/http.conf.tmpl
@@ -73,6 +73,8 @@ upstream {{ $app }}-{{ $process_type }}-{{ $container_port }} {
 {{ $openresty_domains_list := splitList " " $openresty_domains }}
 {{ $openresty_https_port :=              when (contains $first_container.Labels (printf "%s%s" $label_prefix "https-port"))              (index $first_container.Labels (printf "%s%s" $label_prefix "https-port")) "443" }}
 {{ $openresty_basic_auth :=              when (contains $first_container.Labels (printf "%s%s" $label_prefix "basic-auth"))              (index $first_container.Labels (printf "%s%s" $label_prefix "basic-auth")) "" }}
+{{ $openresty_allowed_ips :=             when (contains $first_container.Labels (printf "%s%s" $label_prefix "allowed-ips"))             (index $first_container.Labels (printf "%s%s" $label_prefix "allowed-ips")) "" }}
+{{ $openresty_access_satisfy :=          when (contains $first_container.Labels (printf "%s%s" $label_prefix "access-satisfy"))          (index $first_container.Labels (printf "%s%s" $label_prefix "access-satisfy")) "all" }}
 {{ $openresty_letsencrypt :=             when (contains $first_container.Labels (printf "%s%s" $label_prefix "letsencrypt"))             (index $first_container.Labels (printf "%s%s" $label_prefix "letsencrypt")) "" }}
 {{ $openresty_letsencrypt_enabled := eq $openresty_letsencrypt "true" }}
 {{ $openresty_has_cert := exists (printf "/etc/nginx/ssl/%s-server.key" $app) }}
@@ -139,10 +141,28 @@ server {
 
     {{ else }}
     location / {
-        {{ if $openresty_basic_auth }}
+        {{ if or $openresty_allowed_ips $openresty_basic_auth }}
         access_by_lua_block {
+            {{ if and $openresty_allowed_ips $openresty_basic_auth }}
+            {{ if eq $openresty_access_satisfy "any" }}
+            local allowed_ips = require("allowed_ips")
+            if not allowed_ips.is_allowed([===[{{ $openresty_allowed_ips }}]===]) then
+                local basic_auth = require("basic_auth")
+                basic_auth.check([===[{{ $openresty_basic_auth }}]===])
+            end
+            {{ else }}
+            local allowed_ips = require("allowed_ips")
+            allowed_ips.check([===[{{ $openresty_allowed_ips }}]===])
             local basic_auth = require("basic_auth")
             basic_auth.check([===[{{ $openresty_basic_auth }}]===])
+            {{ end }}
+            {{ else if $openresty_allowed_ips }}
+            local allowed_ips = require("allowed_ips")
+            allowed_ips.check([===[{{ $openresty_allowed_ips }}]===])
+            {{ else }}
+            local basic_auth = require("basic_auth")
+            basic_auth.check([===[{{ $openresty_basic_auth }}]===])
+            {{ end }}
         }
         {{ end }}
         gzip                    on;

--- a/test.bats
+++ b/test.bats
@@ -262,6 +262,114 @@ teardown() {
   assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/http-basic-auth.tmpl)"
 }
 
+@test "[start] http allowed-ips" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  run echo "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/http-allowed-ips.tmpl)"
+}
+
+@test "[start] http allowed-ips + basic-auth" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  run echo "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/http-allowed-ips-basic-auth.tmpl)"
+}
+
+@test "[start] http allowed-ips + basic-auth + access-satisfy any" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=openresty.access-satisfy=any --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  run echo "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/http-allowed-ips-basic-auth-satisfy-any.tmpl)"
+}
+
 @test "[unit] basic-auth lua module" {
   run docker image build -t openresty-docker-proxy:latest .
   echo "output: $output"
@@ -276,6 +384,25 @@ teardown() {
   sleep 3
 
   run docker exec openresty-docker-proxy resty -I /etc/nginx/lua /etc/nginx/lua/test_basic_auth.lua
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
+@test "[unit] allowed-ips lua module" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker exec openresty-docker-proxy resty -I /etc/nginx/lua /etc/nginx/lua/test_allowed_ips.lua
   echo "output: $output"
   echo "status: $status"
   assert_success


### PR DESCRIPTION
## Summary

- Adds `openresty.allowed-ips` label for restricting access by client IPv4 address and CIDR ranges
- Adds `openresty.access-satisfy` label to control interaction with `openresty.basic-auth` (`all` = both must pass, `any` = either grants access)
- Implements IP/CIDR matching in a new Lua module (`allowed_ips.lua`) with unit tests

Closes #44

Follow-ups filed:
- #128 — IPv6 support
- #129 — Configurable IP source for deployments behind load balancers