### PR TITLE
feat: add configurable IP source for allowed-ips

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This label only takes effect when both `openresty.allowed-ips` and `openresty.ba
 
 Restricts access to the app based on client IP address. The value is a space-separated list of IPv4 addresses and CIDR ranges. Requests from non-matching IPs receive a `403 Forbidden` response.
 
-Only IPv4 addresses and CIDR ranges are currently supported. The client IP is determined by `remote_addr`, which is the direct connecting client's IP address. If this proxy runs behind another load balancer, configure `set_real_ip_from` via an include label.
+Only IPv4 addresses and CIDR ranges are currently supported. The client IP is determined by `remote_addr` by default, which is the direct connecting client's IP address. If this proxy runs behind another load balancer, use `openresty.allowed-ips-source` to specify an alternative IP source such as `x-forwarded-for` or `x-real-ip`.
 
 Example usage:
 
@@ -109,6 +109,34 @@ docker run --label='openresty.allowed-ips=10.0.0.0/8' \
 docker run --label='openresty.allowed-ips=10.0.0.0/8' \
            --label='openresty.basic-auth=myuser:{SHA}hash' \
            --label='openresty.access-satisfy=any' myimage
+```
+
+#### `openresty.allowed-ips-source`
+
+> default: `remote_addr`
+
+Controls which source is used to determine the client IP address for `allowed-ips` checks. This is useful when the proxy sits behind another load balancer where `remote_addr` would be the load balancer's IP rather than the real client IP.
+
+Possible values:
+
+- `remote_addr` (default): Uses the direct connecting client's IP address (`ngx.var.remote_addr`).
+- `x-forwarded-for`: Uses the first IP from the `X-Forwarded-For` header. This is typically the original client IP when behind a single load balancer.
+- `x-real-ip`: Uses the `X-Real-IP` header, commonly set by upstream proxies like nginx.
+
+This label only takes effect when `openresty.allowed-ips` is also set.
+
+**Important**: When using `x-forwarded-for` or `x-real-ip`, ensure your upstream load balancer sets these headers correctly. If the header is missing, the request will be denied with `403 Forbidden`.
+
+Example usage:
+
+```bash
+# Behind a load balancer that sets X-Forwarded-For
+docker run --label='openresty.allowed-ips=10.0.0.0/8' \
+           --label='openresty.allowed-ips-source=x-forwarded-for' myimage
+
+# Behind a proxy that sets X-Real-IP
+docker run --label='openresty.allowed-ips=10.0.0.0/8' \
+           --label='openresty.allowed-ips-source=x-real-ip' myimage
 ```
 
 #### `openresty.basic-auth`

--- a/config/allowed_ips.lua
+++ b/config/allowed_ips.lua
@@ -27,12 +27,30 @@ local function cidr_mask(prefix_len)
     return bit.lshift(-1, 32 - prefix_len)
 end
 
--- is_allowed checks whether ngx.var.remote_addr matches any entry
+-- is_allowed checks whether the client IP matches any entry
 -- in the space-separated allowed_ips_str. Each entry is either a
 -- plain IPv4 address (treated as /32) or a CIDR like 10.0.0.0/8.
+-- ip_source selects where the client IP comes from:
+--   nil/""/remote_addr  -> ngx.var.remote_addr (default)
+--   "x-forwarded-for"   -> first IP in X-Forwarded-For header
+--   "x-real-ip"         -> X-Real-IP header
 -- Returns true if the IP matches any entry, false otherwise.
-function _M.is_allowed(allowed_ips_str)
-    local remote_addr = ngx.var.remote_addr
+function _M.is_allowed(allowed_ips_str, ip_source)
+    local remote_addr
+    if ip_source == "x-forwarded-for" then
+        local xff = ngx.var.http_x_forwarded_for
+        if xff then
+            remote_addr = xff:match("^%s*([^,]+)")
+            if remote_addr then
+                remote_addr = remote_addr:match("^%s*(.-)%s*$")
+            end
+        end
+    elseif ip_source == "x-real-ip" then
+        remote_addr = ngx.var.http_x_real_ip
+    else
+        remote_addr = ngx.var.remote_addr
+    end
+
     if not remote_addr then
         return false
     end
@@ -64,8 +82,8 @@ end
 
 -- check denies the request with 403 Forbidden if the client IP
 -- does not match any entry in allowed_ips_str.
-function _M.check(allowed_ips_str)
-    if not _M.is_allowed(allowed_ips_str) then
+function _M.check(allowed_ips_str, ip_source)
+    if not _M.is_allowed(allowed_ips_str, ip_source) then
         ngx.exit(ngx.HTTP_FORBIDDEN)
     end
 end

--- a/config/test_allowed_ips.lua
+++ b/config/test_allowed_ips.lua
@@ -206,6 +206,104 @@ test("Loopback: 127.0.0.1 match", function()
     assert_eq(true, allowed_ips.is_allowed("127.0.0.1"), "should match loopback")
 end)
 
+-- ip_source: x-forwarded-for tests
+
+test("x-forwarded-for: single IP match", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.1"
+    ngx.var.http_x_forwarded_for = "192.168.1.100"
+    assert_eq(true, allowed_ips.is_allowed("192.168.1.0/24", "x-forwarded-for"), "should match XFF IP")
+end)
+
+test("x-forwarded-for: uses first IP from comma-separated list", function()
+    reset_mocks()
+    ngx.var.http_x_forwarded_for = "192.168.1.100, 10.0.0.1, 172.16.0.1"
+    assert_eq(true, allowed_ips.is_allowed("192.168.1.100", "x-forwarded-for"), "should match first IP in XFF")
+end)
+
+test("x-forwarded-for: trims whitespace from first IP", function()
+    reset_mocks()
+    ngx.var.http_x_forwarded_for = " 192.168.1.100 , 10.0.0.1"
+    assert_eq(true, allowed_ips.is_allowed("192.168.1.100", "x-forwarded-for"), "should trim whitespace from XFF IP")
+end)
+
+test("x-forwarded-for: no match returns false", function()
+    reset_mocks()
+    ngx.var.http_x_forwarded_for = "8.8.8.8"
+    assert_eq(false, allowed_ips.is_allowed("192.168.1.0/24", "x-forwarded-for"), "should not match non-allowed XFF IP")
+end)
+
+test("x-forwarded-for: missing header returns false", function()
+    reset_mocks()
+    ngx.var.http_x_forwarded_for = nil
+    assert_eq(false, allowed_ips.is_allowed("0.0.0.0/0", "x-forwarded-for"), "should return false when XFF header missing")
+end)
+
+test("x-forwarded-for: ignores remote_addr", function()
+    reset_mocks()
+    ngx.var.remote_addr = "192.168.1.100"
+    ngx.var.http_x_forwarded_for = "8.8.8.8"
+    assert_eq(false, allowed_ips.is_allowed("192.168.1.100", "x-forwarded-for"), "should use XFF not remote_addr")
+end)
+
+-- ip_source: x-real-ip tests
+
+test("x-real-ip: exact match", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.1"
+    ngx.var.http_x_real_ip = "192.168.1.100"
+    assert_eq(true, allowed_ips.is_allowed("192.168.1.100", "x-real-ip"), "should match X-Real-IP")
+end)
+
+test("x-real-ip: no match returns false", function()
+    reset_mocks()
+    ngx.var.http_x_real_ip = "8.8.8.8"
+    assert_eq(false, allowed_ips.is_allowed("192.168.1.0/24", "x-real-ip"), "should not match non-allowed X-Real-IP")
+end)
+
+test("x-real-ip: missing header returns false", function()
+    reset_mocks()
+    ngx.var.http_x_real_ip = nil
+    assert_eq(false, allowed_ips.is_allowed("0.0.0.0/0", "x-real-ip"), "should return false when X-Real-IP header missing")
+end)
+
+test("x-real-ip: ignores remote_addr", function()
+    reset_mocks()
+    ngx.var.remote_addr = "192.168.1.100"
+    ngx.var.http_x_real_ip = "8.8.8.8"
+    assert_eq(false, allowed_ips.is_allowed("192.168.1.100", "x-real-ip"), "should use X-Real-IP not remote_addr")
+end)
+
+-- ip_source: backward compatibility tests
+
+test("nil ip_source uses remote_addr", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.1"
+    assert_eq(true, allowed_ips.is_allowed("10.0.0.0/8", nil), "nil source should use remote_addr")
+end)
+
+test("explicit remote_addr ip_source uses remote_addr", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.1"
+    assert_eq(true, allowed_ips.is_allowed("10.0.0.0/8", "remote_addr"), "remote_addr source should use remote_addr")
+end)
+
+-- ip_source: check() passthrough tests
+
+test("check with x-forwarded-for: does not exit when XFF IP matches", function()
+    reset_mocks()
+    ngx.var.http_x_forwarded_for = "10.0.0.1"
+    allowed_ips.check("10.0.0.0/8", "x-forwarded-for")
+end)
+
+test("check with x-forwarded-for: exits 403 when XFF IP does not match", function()
+    reset_mocks()
+    ngx.var.http_x_forwarded_for = "192.168.1.1"
+    local ok, err = pcall(allowed_ips.check, "10.0.0.0/8", "x-forwarded-for")
+    assert_eq(false, ok, "should have called ngx.exit")
+    assert_eq(403, mock_exit_code, "should return 403")
+end)
+
 -- Summary
 print("")
 print(string.format("Results: %d/%d tests passed", pass_count, test_count))

--- a/fixtures/http-allowed-ips-source-xff-basic-auth-satisfy-any.tmpl
+++ b/fixtures/http-allowed-ips-source-xff-basic-auth-satisfy-any.tmpl
@@ -1,0 +1,74 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS:5000;
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location / {
+        access_by_lua_block {
+            local allowed_ips = require("allowed_ips")
+            if not allowed_ips.is_allowed([===[10.0.0.0/8 192.168.1.100]===], [===[x-forwarded-for]===]) then
+                local basic_auth = require("basic_auth")
+                basic_auth.check([===[testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=]===])
+            end
+        }
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen      80 default_server;
+    access_log  /var/log/nginx/default-server-80-access.log;
+    error_log   /var/log/nginx/default-server-80-error.log;
+    return      404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    access_log          /var/log/nginx/default-server-443-access.log;
+    error_log           /var/log/nginx/default-server-443-error.log;
+    return              404;
+}

--- a/fixtures/http-allowed-ips-source-xff.tmpl
+++ b/fixtures/http-allowed-ips-source-xff.tmpl
@@ -1,0 +1,71 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS:5000;
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location / {
+        access_by_lua_block {
+            local allowed_ips = require("allowed_ips")
+            allowed_ips.check([===[10.0.0.0/8 192.168.1.100]===], [===[x-forwarded-for]===])
+        }
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen      80 default_server;
+    access_log  /var/log/nginx/default-server-80-access.log;
+    error_log   /var/log/nginx/default-server-80-error.log;
+    return      404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    access_log          /var/log/nginx/default-server-443-access.log;
+    error_log           /var/log/nginx/default-server-443-error.log;
+    return              404;
+}

--- a/fixtures/http-allowed-ips-source-xri.tmpl
+++ b/fixtures/http-allowed-ips-source-xri.tmpl
@@ -1,0 +1,71 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS:5000;
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location / {
+        access_by_lua_block {
+            local allowed_ips = require("allowed_ips")
+            allowed_ips.check([===[10.0.0.0/8 192.168.1.100]===], [===[x-real-ip]===])
+        }
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen      80 default_server;
+    access_log  /var/log/nginx/default-server-80-access.log;
+    error_log   /var/log/nginx/default-server-80-error.log;
+    return      404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    access_log          /var/log/nginx/default-server-443-access.log;
+    error_log           /var/log/nginx/default-server-443-error.log;
+    return              404;
+}

--- a/templates/http.conf.tmpl
+++ b/templates/http.conf.tmpl
@@ -74,6 +74,7 @@ upstream {{ $app }}-{{ $process_type }}-{{ $container_port }} {
 {{ $openresty_https_port :=              when (contains $first_container.Labels (printf "%s%s" $label_prefix "https-port"))              (index $first_container.Labels (printf "%s%s" $label_prefix "https-port")) "443" }}
 {{ $openresty_basic_auth :=              when (contains $first_container.Labels (printf "%s%s" $label_prefix "basic-auth"))              (index $first_container.Labels (printf "%s%s" $label_prefix "basic-auth")) "" }}
 {{ $openresty_allowed_ips :=             when (contains $first_container.Labels (printf "%s%s" $label_prefix "allowed-ips"))             (index $first_container.Labels (printf "%s%s" $label_prefix "allowed-ips")) "" }}
+{{ $openresty_allowed_ips_source :=     when (contains $first_container.Labels (printf "%s%s" $label_prefix "allowed-ips-source"))     (index $first_container.Labels (printf "%s%s" $label_prefix "allowed-ips-source")) "" }}
 {{ $openresty_access_satisfy :=          when (contains $first_container.Labels (printf "%s%s" $label_prefix "access-satisfy"))          (index $first_container.Labels (printf "%s%s" $label_prefix "access-satisfy")) "all" }}
 {{ $openresty_letsencrypt :=             when (contains $first_container.Labels (printf "%s%s" $label_prefix "letsencrypt"))             (index $first_container.Labels (printf "%s%s" $label_prefix "letsencrypt")) "" }}
 {{ $openresty_letsencrypt_enabled := eq $openresty_letsencrypt "true" }}
@@ -146,19 +147,19 @@ server {
             {{ if and $openresty_allowed_ips $openresty_basic_auth }}
             {{ if eq $openresty_access_satisfy "any" }}
             local allowed_ips = require("allowed_ips")
-            if not allowed_ips.is_allowed([===[{{ $openresty_allowed_ips }}]===]) then
+            if not allowed_ips.is_allowed([===[{{ $openresty_allowed_ips }}]===]{{ if $openresty_allowed_ips_source }}, [===[{{ $openresty_allowed_ips_source }}]===]{{ end }}) then
                 local basic_auth = require("basic_auth")
                 basic_auth.check([===[{{ $openresty_basic_auth }}]===])
             end
             {{ else }}
             local allowed_ips = require("allowed_ips")
-            allowed_ips.check([===[{{ $openresty_allowed_ips }}]===])
+            allowed_ips.check([===[{{ $openresty_allowed_ips }}]===]{{ if $openresty_allowed_ips_source }}, [===[{{ $openresty_allowed_ips_source }}]===]{{ end }})
             local basic_auth = require("basic_auth")
             basic_auth.check([===[{{ $openresty_basic_auth }}]===])
             {{ end }}
             {{ else if $openresty_allowed_ips }}
             local allowed_ips = require("allowed_ips")
-            allowed_ips.check([===[{{ $openresty_allowed_ips }}]===])
+            allowed_ips.check([===[{{ $openresty_allowed_ips }}]===]{{ if $openresty_allowed_ips_source }}, [===[{{ $openresty_allowed_ips_source }}]===]{{ end }})
             {{ else }}
             local basic_auth = require("basic_auth")
             basic_auth.check([===[{{ $openresty_basic_auth }}]===])

--- a/test.bats
+++ b/test.bats
@@ -370,6 +370,114 @@ teardown() {
   assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/http-allowed-ips-basic-auth-satisfy-any.tmpl)"
 }
 
+@test "[start] http allowed-ips-source x-forwarded-for" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-forwarded-for --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  run echo "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/http-allowed-ips-source-xff.tmpl)"
+}
+
+@test "[start] http allowed-ips-source x-real-ip" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-real-ip --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  run echo "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/http-allowed-ips-source-xri.tmpl)"
+}
+
+@test "[start] http allowed-ips-source + basic-auth + access-satisfy any" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-forwarded-for '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=openresty.access-satisfy=any --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  run echo "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/http-allowed-ips-source-xff-basic-auth-satisfy-any.tmpl)"
+}
+
 @test "[unit] basic-auth lua module" {
   run docker image build -t openresty-docker-proxy:latest .
   echo "output: $output"


### PR DESCRIPTION
## Summary

- Adds `openresty.allowed-ips-source` label to configure which source is used for IP checking in `allowed-ips` access control
- Supports `remote_addr` (default), `x-forwarded-for` (first IP from header), and `x-real-ip` as IP sources
- Enables deployments behind load balancers to use real client IPs instead of the LB's address

Closes #129