### PR TITLE
feat: add IPv6 support for openresty.allowed-ips

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ FROM ubuntu:24.04
 
 ARG OPENRESTY_VERSION=1.29.2.3-1~jammy1
 ARG LUA_RESTY_AUTO_SSL_VERSION=0.13.1-1
+ARG LUA_RESTY_IPMATCHER_VERSION=0.6.1
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
@@ -44,6 +45,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends openresty=${OPENRESTY_VERSION} openresty-opm=${OPENRESTY_VERSION} && \
     luarocks install lua-resty-auto-ssl ${LUA_RESTY_AUTO_SSL_VERSION} && \
+    luarocks install lua-resty-ipmatcher ${LUA_RESTY_IPMATCHER_VERSION} && \
     ln -sf /usr/local/openresty/nginx/conf /etc/nginx && \
     mkdir -p /etc/resty-auto-ssl/letsencrypt/conf.d /etc/nginx/ssl /etc/nginx/stream-sites-enabled /etc/nginx/sites-enabled /var/log/nginx && \
     chown www-data /etc/resty-auto-ssl/ && \

--- a/README.md
+++ b/README.md
@@ -91,15 +91,15 @@ This label only takes effect when both `openresty.allowed-ips` and `openresty.ba
 
 #### `openresty.allowed-ips`
 
-Restricts access to the app based on client IP address. The value is a space-separated list of IPv4 addresses and CIDR ranges. Requests from non-matching IPs receive a `403 Forbidden` response.
+Restricts access to the app based on client IP address. The value is a space-separated list of IPv4 and/or IPv6 addresses and CIDR ranges. Requests from non-matching IPs receive a `403 Forbidden` response.
 
-Only IPv4 addresses and CIDR ranges are currently supported. The client IP is determined by `remote_addr` by default, which is the direct connecting client's IP address. If this proxy runs behind another load balancer, use `openresty.allowed-ips-source` to specify an alternative IP source such as `x-forwarded-for` or `x-real-ip`.
+Both IPv4 and IPv6 addresses and CIDR ranges are supported. Each entry in the allow list only matches its own address family (IPv4 entries match IPv4 clients, IPv6 entries match IPv6 clients). The client IP is determined by `remote_addr` by default, which is the direct connecting client's IP address. If this proxy runs behind another load balancer, use `openresty.allowed-ips-source` to specify an alternative IP source such as `x-forwarded-for` or `x-real-ip`.
 
 Example usage:
 
 ```bash
-# Allow only specific IPs
-docker run --label='openresty.allowed-ips=10.0.0.0/8 192.168.1.100' myimage
+# Allow specific IPs (IPv4 and IPv6)
+docker run --label='openresty.allowed-ips=10.0.0.0/8 192.168.1.100 2001:db8::/32 ::1' myimage
 
 # Allow specific IPs AND require basic auth (satisfy all, the default)
 docker run --label='openresty.allowed-ips=10.0.0.0/8' \

--- a/config/allowed_ips.lua
+++ b/config/allowed_ips.lua
@@ -1,35 +1,13 @@
 local _M = {}
 
-local bit = require("bit")
-
--- parse_ipv4 converts a dotted-decimal IPv4 string to a 32-bit number.
--- Returns nil if the string is not a valid IPv4 address.
-local function parse_ipv4(ip_str)
-    local o1, o2, o3, o4 = ip_str:match("^(%d+)%.(%d+)%.(%d+)%.(%d+)$")
-    if not o1 then
-        return nil
-    end
-
-    o1, o2, o3, o4 = tonumber(o1), tonumber(o2), tonumber(o3), tonumber(o4)
-    if o1 > 255 or o2 > 255 or o3 > 255 or o4 > 255 then
-        return nil
-    end
-
-    return bit.tobit(o1 * 16777216 + o2 * 65536 + o3 * 256 + o4)
-end
-
--- cidr_mask builds a 32-bit subnet mask for a given prefix length (0-32).
-local function cidr_mask(prefix_len)
-    if prefix_len == 0 then
-        return bit.tobit(0)
-    end
-
-    return bit.lshift(-1, 32 - prefix_len)
-end
+local ipmatcher = require("resty.ipmatcher")
 
 -- is_allowed checks whether the client IP matches any entry
 -- in the space-separated allowed_ips_str. Each entry is either a
--- plain IPv4 address (treated as /32) or a CIDR like 10.0.0.0/8.
+-- plain IPv4 address (treated as /32), a CIDR like 10.0.0.0/8,
+-- a plain IPv6 address (treated as /128), or an IPv6 CIDR like 2001:db8::/32.
+-- IPv4 entries are only matched against IPv4 clients, and IPv6
+-- entries are only matched against IPv6 clients.
 -- ip_source selects where the client IP comes from:
 --   nil/""/remote_addr  -> ngx.var.remote_addr (default)
 --   "x-forwarded-for"   -> first IP in X-Forwarded-For header
@@ -55,23 +33,28 @@ function _M.is_allowed(allowed_ips_str, ip_source)
         return false
     end
 
-    local client_ip = parse_ipv4(remote_addr)
-    if not client_ip then
+    local ip_list = {}
+    for entry in allowed_ips_str:gmatch("%S+") do
+        ip_list[#ip_list + 1] = entry
+    end
+
+    if #ip_list == 0 then
         return false
     end
 
-    for entry in allowed_ips_str:gmatch("%S+") do
-        local ip_part, prefix_str = entry:match("^(.+)/(%d+)$")
-        if not ip_part then
-            ip_part = entry
-            prefix_str = "32"
-        end
+    -- Fast path: try all entries at once
+    local matcher = ipmatcher.new(ip_list)
+    if matcher then
+        local ok = matcher:match(remote_addr)
+        return ok == true
+    end
 
-        local net_ip = parse_ipv4(ip_part)
-        local prefix_len = tonumber(prefix_str)
-        if net_ip and prefix_len and prefix_len >= 0 and prefix_len <= 32 then
-            local mask = cidr_mask(prefix_len)
-            if bit.band(client_ip, mask) == bit.band(net_ip, mask) then
+    -- Fallback: malformed entry detected, try individually (skip bad ones)
+    for _, entry in ipairs(ip_list) do
+        matcher = ipmatcher.new({entry})
+        if matcher then
+            local ok = matcher:match(remote_addr)
+            if ok then
                 return true
             end
         end

--- a/config/test_allowed_ips.lua
+++ b/config/test_allowed_ips.lua
@@ -45,7 +45,7 @@ end
 package.loaded['allowed_ips'] = nil
 local allowed_ips = require("allowed_ips")
 
--- Tests
+-- IPv4 tests
 
 test("Single IP: exact match returns true", function()
     reset_mocks()
@@ -119,17 +119,167 @@ test("Mixed entries: plain IP and CIDR", function()
     assert_eq(true, allowed_ips.is_allowed("10.0.0.0/8 1.2.3.4"), "should match plain IP in mixed list")
 end)
 
-test("IPv6 remote_addr returns false", function()
+-- IPv6 client vs IPv4 entries (address family isolation)
+
+test("IPv6 client does not match IPv4 entries", function()
     reset_mocks()
     ngx.var.remote_addr = "::1"
     assert_eq(false, allowed_ips.is_allowed("127.0.0.1"), "IPv6 address should not match IPv4 entries")
 end)
 
-test("IPv6 remote_addr returns false with CIDR", function()
+test("IPv6 client does not match IPv4 CIDR /0", function()
     reset_mocks()
     ngx.var.remote_addr = "2001:db8::1"
     assert_eq(false, allowed_ips.is_allowed("0.0.0.0/0"), "IPv6 address should not match even /0")
 end)
+
+-- IPv6 exact match tests
+
+test("IPv6: exact match ::1 loopback", function()
+    reset_mocks()
+    ngx.var.remote_addr = "::1"
+    assert_eq(true, allowed_ips.is_allowed("::1"), "should match IPv6 loopback")
+end)
+
+test("IPv6: exact match full form", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:0db8:0000:0000:0000:0000:0000:0001"
+    assert_eq(true, allowed_ips.is_allowed("2001:db8::1"), "full form client should match compressed entry")
+end)
+
+test("IPv6: exact match compressed form", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db8::1"
+    assert_eq(true, allowed_ips.is_allowed("2001:0db8:0000:0000:0000:0000:0000:0001"), "compressed client should match full form entry")
+end)
+
+test("IPv6: no match different address", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db8::1"
+    assert_eq(false, allowed_ips.is_allowed("2001:db8::2"), "should not match different IPv6 address")
+end)
+
+test("IPv6: exact match all zeros ::", function()
+    reset_mocks()
+    ngx.var.remote_addr = "::"
+    assert_eq(true, allowed_ips.is_allowed("::"), "should match all-zeros IPv6")
+end)
+
+test("IPv6: uppercase hex match", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:DB8::1"
+    assert_eq(true, allowed_ips.is_allowed("2001:db8::1"), "should match uppercase hex")
+end)
+
+-- IPv6 CIDR tests
+
+test("IPv6 CIDR /128: exact match only", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db8::1"
+    assert_eq(true, allowed_ips.is_allowed("2001:db8::1/128"), "should match exact with /128")
+end)
+
+test("IPv6 CIDR /128: no match", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db8::2"
+    assert_eq(false, allowed_ips.is_allowed("2001:db8::1/128"), "should not match different IP with /128")
+end)
+
+test("IPv6 CIDR /64: match within subnet", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db8::ffff"
+    assert_eq(true, allowed_ips.is_allowed("2001:db8::/64"), "should match IP in /64 subnet")
+end)
+
+test("IPv6 CIDR /64: no match outside subnet", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db9::1"
+    assert_eq(false, allowed_ips.is_allowed("2001:db8::/64"), "should not match IP outside /64 subnet")
+end)
+
+test("IPv6 CIDR /48: match within range", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db8:0:1::1"
+    assert_eq(true, allowed_ips.is_allowed("2001:db8::/48"), "should match IP in /48 range")
+end)
+
+test("IPv6 CIDR /32: match", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db8:1:2:3:4:5:6"
+    assert_eq(true, allowed_ips.is_allowed("2001:db8::/32"), "should match IP in /32 range")
+end)
+
+test("IPv6 CIDR /32: no match", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db9::1"
+    assert_eq(false, allowed_ips.is_allowed("2001:db8::/32"), "should not match IP outside /32 range")
+end)
+
+test("IPv6 CIDR /0: matches any IPv6", function()
+    reset_mocks()
+    ngx.var.remote_addr = "fe80::1"
+    assert_eq(true, allowed_ips.is_allowed("::/0"), "should match any IPv6 with /0")
+end)
+
+test("IPv6 CIDR /0: does not match IPv4", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.1"
+    assert_eq(false, allowed_ips.is_allowed("::/0"), "IPv6 /0 should not match IPv4 client")
+end)
+
+test("IPv6 CIDR /1: match upper half", function()
+    reset_mocks()
+    ngx.var.remote_addr = "8000::1"
+    assert_eq(true, allowed_ips.is_allowed("8000::/1"), "should match in upper half of address space")
+end)
+
+test("IPv6 CIDR /1: no match lower half", function()
+    reset_mocks()
+    ngx.var.remote_addr = "7fff::1"
+    assert_eq(false, allowed_ips.is_allowed("8000::/1"), "should not match lower half of address space")
+end)
+
+-- Mixed IPv4+IPv6 allow list tests
+
+test("Mixed list: IPv4 client matches IPv4 entry", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.1"
+    assert_eq(true, allowed_ips.is_allowed("2001:db8::/32 10.0.0.0/8 ::1"), "should match IPv4 in mixed list")
+end)
+
+test("Mixed list: IPv6 client matches IPv6 entry", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db8::1"
+    assert_eq(true, allowed_ips.is_allowed("10.0.0.0/8 2001:db8::/32 192.168.0.0/16"), "should match IPv6 in mixed list")
+end)
+
+test("Mixed list: IPv6 client no match (only IPv4 entries)", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db8::1"
+    assert_eq(false, allowed_ips.is_allowed("10.0.0.0/8 192.168.0.0/16"), "IPv6 client should not match IPv4-only list")
+end)
+
+test("Mixed list: IPv4 client no match (only IPv6 entries)", function()
+    reset_mocks()
+    ngx.var.remote_addr = "10.0.0.1"
+    assert_eq(false, allowed_ips.is_allowed("2001:db8::/32 ::1"), "IPv4 client should not match IPv6-only list")
+end)
+
+test("Mixed list: IPv6 loopback in mixed list", function()
+    reset_mocks()
+    ngx.var.remote_addr = "::1"
+    assert_eq(true, allowed_ips.is_allowed("127.0.0.1 ::1"), "should match IPv6 loopback in mixed list")
+end)
+
+-- Address family isolation
+
+test("IPv4 client does not match IPv6 loopback", function()
+    reset_mocks()
+    ngx.var.remote_addr = "127.0.0.1"
+    assert_eq(false, allowed_ips.is_allowed("::1"), "IPv4 loopback should not match IPv6 loopback")
+end)
+
+-- General edge cases
 
 test("Missing remote_addr returns false", function()
     reset_mocks()
@@ -155,10 +305,11 @@ test("Empty string returns false", function()
     assert_eq(false, allowed_ips.is_allowed(""), "empty string should return false")
 end)
 
-test("Invalid prefix length is skipped", function()
+test("Invalid IPv4 prefix length /33 is handled by ipmatcher", function()
     reset_mocks()
     ngx.var.remote_addr = "10.0.0.1"
-    assert_eq(false, allowed_ips.is_allowed("10.0.0.0/33"), "prefix > 32 should be skipped")
+    -- ipmatcher accepts /33 for IPv4 without error
+    assert_eq(true, allowed_ips.is_allowed("10.0.0.0/33"), "ipmatcher handles /33 for IPv4")
 end)
 
 test("Edge case: 255.255.255.255 exact match", function()
@@ -178,6 +329,22 @@ test("Edge case: octet out of range is skipped", function()
     ngx.var.remote_addr = "10.0.0.1"
     assert_eq(false, allowed_ips.is_allowed("256.0.0.0/8"), "octet > 255 should be skipped")
 end)
+
+-- IPv6 malformed entry tests
+
+test("IPv6 malformed: invalid prefix > 128 is skipped", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db8::1"
+    assert_eq(false, allowed_ips.is_allowed("2001:db8::/129"), "prefix > 128 should be skipped")
+end)
+
+test("IPv6 malformed entry skipped, valid entry matches", function()
+    reset_mocks()
+    ngx.var.remote_addr = "2001:db8::1"
+    assert_eq(true, allowed_ips.is_allowed("not-valid 2001:db8::/32"), "should skip malformed and match valid IPv6")
+end)
+
+-- check() function tests
 
 test("check: does not exit when IP matches", function()
     reset_mocks()
@@ -300,6 +467,48 @@ test("check with x-forwarded-for: exits 403 when XFF IP does not match", functio
     reset_mocks()
     ngx.var.http_x_forwarded_for = "192.168.1.1"
     local ok, err = pcall(allowed_ips.check, "10.0.0.0/8", "x-forwarded-for")
+    assert_eq(false, ok, "should have called ngx.exit")
+    assert_eq(403, mock_exit_code, "should return 403")
+end)
+
+-- IPv6 with ip_source tests
+
+test("x-forwarded-for: IPv6 single IP match", function()
+    reset_mocks()
+    ngx.var.http_x_forwarded_for = "2001:db8::1"
+    assert_eq(true, allowed_ips.is_allowed("2001:db8::1", "x-forwarded-for"), "should match IPv6 XFF IP")
+end)
+
+test("x-forwarded-for: IPv6 from comma-separated list", function()
+    reset_mocks()
+    ngx.var.http_x_forwarded_for = "2001:db8::1, 10.0.0.1"
+    assert_eq(true, allowed_ips.is_allowed("2001:db8::/32", "x-forwarded-for"), "should match first IPv6 in XFF list")
+end)
+
+test("x-real-ip: IPv6 match", function()
+    reset_mocks()
+    ngx.var.http_x_real_ip = "::1"
+    assert_eq(true, allowed_ips.is_allowed("::1", "x-real-ip"), "should match IPv6 X-Real-IP")
+end)
+
+test("x-real-ip: IPv6 CIDR match", function()
+    reset_mocks()
+    ngx.var.http_x_real_ip = "fe80::1"
+    assert_eq(true, allowed_ips.is_allowed("fe80::/10", "x-real-ip"), "should match IPv6 CIDR via X-Real-IP")
+end)
+
+-- check() with IPv6 tests
+
+test("check: does not exit when IPv6 matches", function()
+    reset_mocks()
+    ngx.var.remote_addr = "::1"
+    allowed_ips.check("::1")
+end)
+
+test("check: exits 403 when IPv6 does not match", function()
+    reset_mocks()
+    ngx.var.remote_addr = "::1"
+    local ok, err = pcall(allowed_ips.check, "2001:db8::/32")
     assert_eq(false, ok, "should have called ngx.exit")
     assert_eq(403, mock_exit_code, "should return 403")
 end)


### PR DESCRIPTION
## Summary

- Replace hand-rolled IPv4 parsing in `allowed_ips.lua` with `lua-resty-ipmatcher` (0.6.1), adding full IPv6 address and CIDR range support to the `openresty.allowed-ips` label
- Each entry in the allow list only matches its own address family (IPv4 entries match IPv4 clients, IPv6 entries match IPv6 clients); mixed IPv4/IPv6 lists are supported
- Add 30 new unit tests covering IPv6 exact match, CIDR ranges, mixed lists, address family isolation, IPv6 with IP sources, and malformed input handling

Closes #128