### PR TITLE
feat: add openresty.route.<n> labels for path-based routing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
         run: docker image build -t openresty-docker-proxy:latest .
 
       - name: Pull test image
-        run: docker image pull --platform linux/amd64 dokku/python-sample
+        run: docker image pull traefik/whoami
 
       - name: Run tests
         run: bats test.bats

--- a/README.md
+++ b/README.md
@@ -248,6 +248,33 @@ Defines a timeout for reading a response from the proxied server.
 
 Defines a timeout for sending a request to the proxied server.
 
+#### `openresty.route.<n>.path-prefix`
+
+Declares a path prefix on a non-`web` container that should be routed to that container instead of falling through to the web upstream. Combined with `openresty.route.<n>.port` (required) and `openresty.route.<n>.strip-prefix` (optional), this lets a single hostname fan requests out to multiple Procfile processes. `<n>` is a numeric index that disambiguates multiple routes on the same container; nginx longest-prefix-match handles ordering, so the index only needs to be stable, not specific.
+
+For each labeled route, the sidecar emits an upstream pointing at the non-`web` container's IP at the labeled port and a `location <path-prefix>` block inside every `server { }` block produced for the app's domains. Requests that do not match any labeled prefix fall through to the existing `location /` that proxies the web upstream. The route locations inherit the app's WebSocket headers, proxy buffer/timeout settings, and access controls (`openresty.basic-auth`, `openresty.allowed-ips`, `openresty.access-satisfy`) from the web container.
+
+Example usage:
+
+```bash
+docker run --label=openresty.port-mapping=http:80:5001 \
+           --label=openresty.route.0.path-prefix=/api/v0 \
+           --label=openresty.route.0.port=5001 \
+           --label=com.dokku.app-name=myapp \
+           --label=com.dokku.process-type=api \
+           myimage
+```
+
+#### `openresty.route.<n>.port`
+
+The upstream port on the non-`web` container that requests matching `openresty.route.<n>.path-prefix` should be forwarded to. Required when a `path-prefix` is set; the route is skipped if this label is absent.
+
+#### `openresty.route.<n>.strip-prefix`
+
+> default: `false`
+
+When `true`, the matched `path-prefix` is stripped from the request before it is forwarded upstream (nginx renders `proxy_pass http://<upstream>/;` with a trailing slash). Use this when the upstream process is written assuming it is mounted at root (so it sees `/users/42` instead of `/api/v0/users/42`). When `false` or unset, the upstream sees the full original request path.
+
 #### `openresty.send-timeout`
 
 Defines a timeout for sending a response to the client.

--- a/fixtures/http-route-multiple.tmpl
+++ b/fixtures/http-route-multiple.tmpl
@@ -88,7 +88,8 @@ server {
         proxy_busy_buffers_size 8192;
         proxy_connect_timeout   60s;
         proxy_http_version      1.1;
-        proxy_pass              http://python-api-5001/;
+        rewrite                 ^/internal/?(.*)$ /$1 break;
+        proxy_pass              http://python-api-5001;
         proxy_read_timeout      60s;
         proxy_send_timeout      60s;
         send_timeout            60s;

--- a/fixtures/http-route-multiple.tmpl
+++ b/fixtures/http-route-multiple.tmpl
@@ -1,0 +1,120 @@
+upstream python-api-5001 {
+    server VAR_IP_ADDRESS_API:5001;
+}
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS_WEB:5000;
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location / {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    location /api/v0 {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-api-5001;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+    location /internal {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-api-5001/;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen      80 default_server;
+    access_log  /var/log/nginx/default-server-80-access.log;
+    error_log   /var/log/nginx/default-server-80-error.log;
+    return      404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    access_log          /var/log/nginx/default-server-443-access.log;
+    error_log           /var/log/nginx/default-server-443-error.log;
+    return              404;
+}

--- a/fixtures/http-route-strip-prefix.tmpl
+++ b/fixtures/http-route-strip-prefix.tmpl
@@ -1,0 +1,95 @@
+upstream python-api-5001 {
+    server VAR_IP_ADDRESS_API:5001;
+}
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS_WEB:5000;
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location / {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    location /api/v0 {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-api-5001/;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen      80 default_server;
+    access_log  /var/log/nginx/default-server-80-access.log;
+    error_log   /var/log/nginx/default-server-80-error.log;
+    return      404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    access_log          /var/log/nginx/default-server-443-access.log;
+    error_log           /var/log/nginx/default-server-443-error.log;
+    return              404;
+}

--- a/fixtures/http-route-strip-prefix.tmpl
+++ b/fixtures/http-route-strip-prefix.tmpl
@@ -63,7 +63,8 @@ server {
         proxy_busy_buffers_size 8192;
         proxy_connect_timeout   60s;
         proxy_http_version      1.1;
-        proxy_pass              http://python-api-5001/;
+        rewrite                 ^/api/v0/?(.*)$ /$1 break;
+        proxy_pass              http://python-api-5001;
         proxy_read_timeout      60s;
         proxy_send_timeout      60s;
         send_timeout            60s;

--- a/fixtures/http-route.tmpl
+++ b/fixtures/http-route.tmpl
@@ -1,0 +1,95 @@
+upstream python-api-5001 {
+    server VAR_IP_ADDRESS_API:5001;
+}
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS_WEB:5000;
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location / {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    location /api/v0 {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-api-5001;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen      80 default_server;
+    access_log  /var/log/nginx/default-server-80-access.log;
+    error_log   /var/log/nginx/default-server-80-error.log;
+    return      404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    access_log          /var/log/nginx/default-server-443-access.log;
+    error_log           /var/log/nginx/default-server-443-error.log;
+    return              404;
+}

--- a/fixtures/https-route.cert.tmpl
+++ b/fixtures/https-route.cert.tmpl
@@ -1,0 +1,112 @@
+upstream python-api-5001 {
+    server VAR_IP_ADDRESS_API:5001;
+}
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS_WEB:5000;
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location / {
+        return 301 https://$host:443$request_uri;
+    }
+}
+server {
+    listen                      [::]:443 ssl http2;
+    listen                      443 ssl http2;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    ssl_certificate             /etc/nginx/ssl/python-server.crt;
+    ssl_certificate_key         /etc/nginx/ssl/python-server.key;
+    ssl_protocols               TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers   off;
+    keepalive_timeout           70;
+    location / {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+        http2_push_preload      on;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    location /api/v0 {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_connect_timeout   60s;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-api-5001;
+        proxy_read_timeout      60s;
+        proxy_send_timeout      60s;
+        send_timeout            60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+        http2_push_preload      on;
+    }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen      80 default_server;
+    access_log  /var/log/nginx/default-server-80-access.log;
+    error_log   /var/log/nginx/default-server-80-error.log;
+    return      404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    access_log          /var/log/nginx/default-server-443-access.log;
+    error_log           /var/log/nginx/default-server-443-error.log;
+    return              404;
+}

--- a/templates/http.conf.tmpl
+++ b/templates/http.conf.tmpl
@@ -46,6 +46,34 @@ upstream {{ $app }}-{{ $process_type }}-{{ $container_port }} {
 {{ end }}{{/* endif scheme in http|https */}}
 {{ end }}{{/* endif contains upstream_name */}}
 {{ end }}{{/* endrange port_mappings */}}
+
+{{ if ne $process_type $web_process }}
+{{ range $label, $value := $first_container.Labels }}
+{{ if and (hasPrefix (printf "%sroute." $label_prefix) $label) (hasSuffix ".path-prefix" $label) }}
+{{ $route_index := trimSuffix ".path-prefix" (trimPrefix (printf "%sroute." $label_prefix) $label) }}
+{{ $port_label := printf "%sroute.%s.port" $label_prefix $route_index }}
+{{ if contains $first_container.Labels $port_label }}
+{{ $route_port := index $first_container.Labels $port_label }}
+{{ $upstream_name := printf "%s-%s-%s" $app $process_type $route_port }}
+{{ if not (contains $upstreams $upstream_name) }}
+{{ $_ := set $upstreams $upstream_name true }}
+upstream {{ $upstream_name }} {
+{{ range $_, $container := $containers }}
+{{ range $_, $network := $container.Networks }}
+    {{ if eq (env "OPENRESTY_DEBUG") "true" }}
+        # current_network={{ $network.Name }} initial_network={{ $initial_network }}
+    {{ end }}
+{{ if eq $network.Name $initial_network }}
+    server {{ $container.IP }}:{{ $route_port }};{{ if eq (env "OPENRESTY_DEBUG") "true" }} # app={{ $app }} process_type={{ $process_type }} route_port={{ $route_port }} route_path={{ $value }} network={{ $network.Name }}{{ end }}
+{{ end }}{{/* endif initial_network */}}
+{{ end }}{{/* endrange networks */}}
+{{ end }}{{/* endrange containers */}}
+}
+{{ end }}{{/* endif new upstream */}}
+{{ end }}{{/* endif port label exists */}}
+{{ end }}{{/* endif route path-prefix label */}}
+{{ end }}{{/* endrange labels for route discovery */}}
+{{ end }}{{/* endif non-web process */}}
 {{ end }}{{/* endrange groupByLabel appContainers */}}
 
 {{ if (contains $all_app_containers $web_process) }}
@@ -216,6 +244,74 @@ server {
         root /etc/nginx/errors;
         internal;
     }
+
+    {{ range $route_process_type, $route_proc_containers := $all_app_containers }}
+    {{ if ne $route_process_type $web_process }}
+    {{ $route_first := index $route_proc_containers 0 }}
+    {{ range $label, $value := $route_first.Labels }}
+    {{ if and (hasPrefix (printf "%sroute." $label_prefix) $label) (hasSuffix ".path-prefix" $label) }}
+    {{ $route_index := trimSuffix ".path-prefix" (trimPrefix (printf "%sroute." $label_prefix) $label) }}
+    {{ $port_label := printf "%sroute.%s.port" $label_prefix $route_index }}
+    {{ if contains $route_first.Labels $port_label }}
+    {{ $route_port := index $route_first.Labels $port_label }}
+    {{ $strip_label := printf "%sroute.%s.strip-prefix" $label_prefix $route_index }}
+    {{ $strip_prefix := eq (when (contains $route_first.Labels $strip_label) (index $route_first.Labels $strip_label) "false") "true" }}
+    location {{ $value }} {
+        {{ if or $openresty_allowed_ips $openresty_basic_auth }}
+        access_by_lua_block {
+            {{ if and $openresty_allowed_ips $openresty_basic_auth }}
+            {{ if eq $openresty_access_satisfy "any" }}
+            local allowed_ips = require("allowed_ips")
+            if not allowed_ips.is_allowed([===[{{ $openresty_allowed_ips }}]===]{{ if $openresty_allowed_ips_source }}, [===[{{ $openresty_allowed_ips_source }}]===]{{ end }}) then
+                local basic_auth = require("basic_auth")
+                basic_auth.check([===[{{ $openresty_basic_auth }}]===])
+            end
+            {{ else }}
+            local allowed_ips = require("allowed_ips")
+            allowed_ips.check([===[{{ $openresty_allowed_ips }}]===]{{ if $openresty_allowed_ips_source }}, [===[{{ $openresty_allowed_ips_source }}]===]{{ end }})
+            local basic_auth = require("basic_auth")
+            basic_auth.check([===[{{ $openresty_basic_auth }}]===])
+            {{ end }}
+            {{ else if $openresty_allowed_ips }}
+            local allowed_ips = require("allowed_ips")
+            allowed_ips.check([===[{{ $openresty_allowed_ips }}]===]{{ if $openresty_allowed_ips_source }}, [===[{{ $openresty_allowed_ips_source }}]===]{{ end }})
+            {{ else }}
+            local basic_auth = require("basic_auth")
+            basic_auth.check([===[{{ $openresty_basic_auth }}]===])
+            {{ end }}
+        }
+        {{ end }}
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       {{ $openresty_proxy_buffer_size }};
+        proxy_buffering         {{ $openresty_proxy_buffering }};
+        proxy_buffers           {{ $openresty_proxy_buffers }};
+        proxy_busy_buffers_size {{ $openresty_proxy_busy_buffer_size }};
+        proxy_connect_timeout   {{ $openresty_proxy_connect_timeout }};
+        proxy_http_version      1.1;
+        proxy_pass              http://{{ $app }}-{{ $route_process_type }}-{{ $route_port }}{{ if $strip_prefix }}/{{ end }};
+        proxy_read_timeout      {{ $openresty_proxy_read_timeout }};
+        proxy_send_timeout      {{ $openresty_proxy_send_timeout }};
+        send_timeout            {{ $openresty_send_timeout }};
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For {{ $openresty_x_forwarded_for_value }};
+        proxy_set_header        X-Forwarded-Port {{ $openresty_x_forwarded_port_value }};
+        proxy_set_header        X-Forwarded-Proto {{ $openresty_x_forwarded_proto_value }};
+        proxy_set_header        X-Request-Start $msec;
+        {{ if $openresty_x_forwarded_ssl }}proxy_set_header       X-Forwarded-Ssl {{ $openresty_x_forwarded_ssl }};{{ end }}
+        {{ if and (eq $scheme "https") $openresty_ssl_enabled }}http2_push_preload      on;{{ end }}
+    }
+    {{ end }}{{/* endif port label exists */}}
+    {{ end }}{{/* endif route path-prefix label */}}
+    {{ end }}{{/* endrange labels for route locations */}}
+    {{ end }}{{/* endif non-web process */}}
+    {{ end }}{{/* endrange all_app_containers for routes */}}
 
     {{ range $label, $base64Value := $first_container.Labels }}
     {{ if hasPrefix (printf "%s%s" $label_prefix "include-http-") $label }}

--- a/templates/http.conf.tmpl
+++ b/templates/http.conf.tmpl
@@ -293,7 +293,8 @@ server {
         proxy_busy_buffers_size {{ $openresty_proxy_busy_buffer_size }};
         proxy_connect_timeout   {{ $openresty_proxy_connect_timeout }};
         proxy_http_version      1.1;
-        proxy_pass              http://{{ $app }}-{{ $route_process_type }}-{{ $route_port }}{{ if $strip_prefix }}/{{ end }};
+        {{ if $strip_prefix }}rewrite                 ^{{ $value }}/?(.*)$ /$1 break;{{ end }}
+        proxy_pass              http://{{ $app }}-{{ $route_process_type }}-{{ $route_port }};
         proxy_read_timeout      {{ $openresty_proxy_read_timeout }};
         proxy_send_timeout      {{ $openresty_proxy_send_timeout }};
         send_timeout            {{ $openresty_send_timeout }};

--- a/templates/http.conf.tmpl
+++ b/templates/http.conf.tmpl
@@ -38,7 +38,7 @@ upstream {{ $app }}-{{ $process_type }}-{{ $container_port }} {
         # current_network={{ $network.Name }} initial_network={{ $initial_network }}
     {{ end }}
 {{ if eq $network.Name $initial_network }}
-    server {{ $container.IP }}:{{ $container_port }};{{ if eq (env "OPENRESTY_DEBUG") "true" }} # app={{ $app }} process_type={{ $process_type }} container_port={{ $container_port }} network={{ $network.Name }} scheme={{ $scheme }}{{ end }}
+    server {{ $network.IP }}:{{ $container_port }};{{ if eq (env "OPENRESTY_DEBUG") "true" }} # app={{ $app }} process_type={{ $process_type }} container_port={{ $container_port }} network={{ $network.Name }} scheme={{ $scheme }}{{ end }}
 {{ end }}{{/* endif initial_network */}}
 {{ end }}{{/* endrange networks */}}
 {{ end }}{{/* endrange containers */}}
@@ -64,7 +64,7 @@ upstream {{ $upstream_name }} {
         # current_network={{ $network.Name }} initial_network={{ $initial_network }}
     {{ end }}
 {{ if eq $network.Name $initial_network }}
-    server {{ $container.IP }}:{{ $route_port }};{{ if eq (env "OPENRESTY_DEBUG") "true" }} # app={{ $app }} process_type={{ $process_type }} route_port={{ $route_port }} route_path={{ $value }} network={{ $network.Name }}{{ end }}
+    server {{ $network.IP }}:{{ $route_port }};{{ if eq (env "OPENRESTY_DEBUG") "true" }} # app={{ $app }} process_type={{ $process_type }} route_port={{ $route_port }} route_path={{ $value }} network={{ $network.Name }}{{ end }}
 {{ end }}{{/* endif initial_network */}}
 {{ end }}{{/* endrange networks */}}
 {{ end }}{{/* endrange containers */}}

--- a/templates/stream.conf.tmpl
+++ b/templates/stream.conf.tmpl
@@ -24,7 +24,7 @@ upstream {{ $app }}-{{ $process_type }}-{{ $container_port }}-{{ $scheme }} {
 {{ range $_, $container := $containers }}
 {{ range $_, $network := $container.Networks }}
 {{ if eq $network.Name $initial_network }}
-    server {{ $container.IP }}:{{ $container_port }}; # network={{ $network.Name }}
+    server {{ $network.IP }}:{{ $container_port }}; # network={{ $network.Name }}
 {{ end }}{{/* endif initial_network */}}
 {{ end }}{{/* endrange networks */}}
 {{ end }}{{/* endrange containers */}}

--- a/test.bats
+++ b/test.bats
@@ -76,7 +76,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=grpc:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=grpc:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -129,7 +129,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com '--label=openresty.port-mapping=grpcs:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d dokku/python-sample /start web
+  run docker run --rm --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=grpcs:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -165,7 +165,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com '--label=openresty.port-mapping=grpcs:443:5000' --label=openresty.letsencrypt=true --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=grpcs:443:5000' --label=openresty.letsencrypt=true --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -201,7 +201,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -237,7 +237,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -273,7 +273,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -309,7 +309,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -345,7 +345,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=openresty.access-satisfy=any --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=openresty.access-satisfy=any --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -381,7 +381,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-forwarded-for --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-forwarded-for --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -417,7 +417,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-real-ip --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-real-ip --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -453,7 +453,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-forwarded-for '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=openresty.access-satisfy=any --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-forwarded-for '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=openresty.access-satisfy=any --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -489,12 +489,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file-2 --platform linux/amd64 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -531,12 +531,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file-2 --platform linux/amd64 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.0.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.0.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -573,12 +573,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file-2 --platform linux/amd64 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.1.path-prefix=/internal --label=openresty.route.1.port=5001 --label=openresty.route.1.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.1.path-prefix=/internal --label=openresty.route.1.port=5001 --label=openresty.route.1.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -632,12 +632,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d dokku/python-sample /start web
+  run docker run --rm --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run docker run --rm --cidfile /tmp/cid-file-2 --platform linux/amd64 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" -d dokku/python-sample /start web
+  run docker run --rm --cidfile /tmp/cid-file-2 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" -d traefik/whoami -port=:5001
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -661,6 +661,151 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_output_cr "$(sed -e "s/VAR_IP_ADDRESS_WEB/$IP_ADDRESS_WEB/" -e "s/VAR_IP_ADDRESS_API/$IP_ADDRESS_API/" fixtures/https-route.cert.tmpl)"
+}
+
+@test "[curl] http route hits api upstream on prefix match" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -p 1080:80 -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --hostname web-upstream --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --hostname api-upstream --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 5
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run curl -sS -H "Host: python.example.com" http://127.0.0.1:1080/api/v0/users
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "Hostname: api-upstream"
+  assert_output_contains "GET /api/v0/users HTTP/1.1"
+}
+
+@test "[curl] http route falls through to web on no prefix match" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -p 1080:80 -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --hostname web-upstream --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --hostname api-upstream --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 5
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run curl -sS -H "Host: python.example.com" http://127.0.0.1:1080/anything-else
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "Hostname: web-upstream"
+  assert_output_contains "GET /anything-else HTTP/1.1"
+}
+
+@test "[curl] http route strip-prefix strips matched prefix" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -p 1080:80 -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --hostname web-upstream --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --hostname api-upstream --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.0.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 5
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run curl -sS -H "Host: python.example.com" http://127.0.0.1:1080/api/v0/users
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "Hostname: api-upstream"
+  assert_output_contains "GET /users HTTP/1.1"
+}
+
+@test "[curl] http route forwards websocket upgrade headers to upstream" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -p 1080:80 -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --hostname web-upstream --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --hostname api-upstream --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 5
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run curl -sS -H "Host: python.example.com" -H "Upgrade: websocket" -H "Connection: Upgrade" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" -H "Sec-WebSocket-Version: 13" http://127.0.0.1:1080/api/v0/socket
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "Hostname: api-upstream"
+  assert_output_contains "Upgrade: websocket"
+  assert_output_contains "Connection: Upgrade"
 }
 
 @test "[unit] basic-auth lua module" {
@@ -714,7 +859,7 @@ teardown() {
 
   DATA="$(cat fixtures/includes/v1.conf | base64)"
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 "--label=openresty.include-http-v1.conf=$DATA" --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 "--label=openresty.include-http-v1.conf=$DATA" --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -767,7 +912,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d dokku/python-sample /start web
+  run docker run --rm --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -803,7 +948,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=openresty.letsencrypt=true --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d dokku/python-sample /start web
+  run docker run --rm --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=openresty.letsencrypt=true --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -827,7 +972,7 @@ teardown() {
   assert_success
   assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/https.letsencrypt.tmpl)"
 
-  run docker run --rm --cidfile /tmp/cid-file-2 --platform linux/amd64 '--label=openresty.domains=python2.example.com _' '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=openresty.letsencrypt=true --label=com.dokku.app-name=python2 --label=com.dokku.process-type=web --name "${TEST_CONTAINER_NAME}_2" -d dokku/python-sample /start web
+  run docker run --rm --cidfile /tmp/cid-file-2 '--label=openresty.domains=python2.example.com _' '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=openresty.letsencrypt=true --label=com.dokku.app-name=python2 --label=com.dokku.process-type=web --name "${TEST_CONTAINER_NAME}_2" -d traefik/whoami -port=:5000
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/test.bats
+++ b/test.bats
@@ -76,7 +76,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=grpc:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=grpc:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -88,7 +88,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -129,7 +129,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=grpcs:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d traefik/whoami -port=:5000
+  run docker run --rm --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=grpcs:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -141,7 +141,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -165,7 +165,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=grpcs:443:5000' --label=openresty.letsencrypt=true --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=grpcs:443:5000' --label=openresty.letsencrypt=true --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -177,7 +177,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -201,7 +201,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -213,7 +213,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -237,7 +237,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -249,7 +249,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -273,7 +273,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -285,7 +285,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -309,7 +309,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -321,7 +321,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -345,7 +345,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=openresty.access-satisfy=any --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=openresty.access-satisfy=any --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -357,7 +357,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -381,7 +381,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-forwarded-for --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-forwarded-for --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -393,7 +393,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -417,7 +417,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-real-ip --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-real-ip --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -429,7 +429,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -453,7 +453,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-forwarded-for '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=openresty.access-satisfy=any --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 '--label=openresty.allowed-ips=10.0.0.0/8 192.168.1.100' --label=openresty.allowed-ips-source=x-forwarded-for '--label=openresty.basic-auth=testuser:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=' --label=openresty.access-satisfy=any --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -465,7 +465,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -489,12 +489,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file-2 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=5001
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -506,8 +506,8 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS_WEB="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
-  IP_ADDRESS_API="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "${TEST_CONTAINER_NAME}_2")"
+  IP_ADDRESS_WEB="$(get_container_ip "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS_API="$(get_container_ip "${TEST_CONTAINER_NAME}_2")"
   run echo "web=$IP_ADDRESS_WEB api=$IP_ADDRESS_API"
   echo "output: $output"
   echo "status: $status"
@@ -531,12 +531,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file-2 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.0.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.0.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=5001
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -548,8 +548,8 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS_WEB="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
-  IP_ADDRESS_API="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "${TEST_CONTAINER_NAME}_2")"
+  IP_ADDRESS_WEB="$(get_container_ip "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS_API="$(get_container_ip "${TEST_CONTAINER_NAME}_2")"
   run echo "web=$IP_ADDRESS_WEB api=$IP_ADDRESS_API"
   echo "output: $output"
   echo "status: $status"
@@ -573,12 +573,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file-2 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.1.path-prefix=/internal --label=openresty.route.1.port=5001 --label=openresty.route.1.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.1.path-prefix=/internal --label=openresty.route.1.port=5001 --label=openresty.route.1.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=5001
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -590,8 +590,8 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS_WEB="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
-  IP_ADDRESS_API="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "${TEST_CONTAINER_NAME}_2")"
+  IP_ADDRESS_WEB="$(get_container_ip "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS_API="$(get_container_ip "${TEST_CONTAINER_NAME}_2")"
   run echo "web=$IP_ADDRESS_WEB api=$IP_ADDRESS_API"
   echo "output: $output"
   echo "status: $status"
@@ -632,12 +632,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d traefik/whoami -port=:5000
+  run docker run --rm --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run docker run --rm --cidfile /tmp/cid-file-2 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" -d traefik/whoami -port=:5001
+  run docker run --rm --cidfile /tmp/cid-file-2 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" -d traefik/whoami -port=5001
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -649,8 +649,8 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS_WEB="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
-  IP_ADDRESS_API="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "${TEST_CONTAINER_NAME}_2")"
+  IP_ADDRESS_WEB="$(get_container_ip "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS_API="$(get_container_ip "${TEST_CONTAINER_NAME}_2")"
   run echo "web=$IP_ADDRESS_WEB api=$IP_ADDRESS_API"
   echo "output: $output"
   echo "status: $status"
@@ -674,12 +674,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --hostname web-upstream --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --hostname web-upstream --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file-2 --hostname api-upstream --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --hostname api-upstream --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=5001
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -710,12 +710,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --hostname web-upstream --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --hostname web-upstream --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file-2 --hostname api-upstream --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --hostname api-upstream --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=5001
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -746,12 +746,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --hostname web-upstream --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --hostname web-upstream --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file-2 --hostname api-upstream --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.0.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --hostname api-upstream --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.0.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=5001
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -782,12 +782,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --hostname web-upstream --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --hostname web-upstream --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file-2 --hostname api-upstream --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=:5001
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --hostname api-upstream --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=5001
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -859,7 +859,7 @@ teardown() {
 
   DATA="$(cat fixtures/includes/v1.conf | base64)"
 
-  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 "--label=openresty.include-http-v1.conf=$DATA" --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=:5000
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 "--label=openresty.include-http-v1.conf=$DATA" --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -871,7 +871,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -912,7 +912,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d traefik/whoami -port=:5000
+  run docker run --rm --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -924,7 +924,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -948,7 +948,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=openresty.letsencrypt=true --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d traefik/whoami -port=:5000
+  run docker run --rm --cidfile /tmp/cid-file --label=openresty.domains=python.example.com '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=openresty.letsencrypt=true --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -960,7 +960,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS="$(get_container_ip "$TEST_CONTAINER_NAME")"
   run echo "$IP_ADDRESS"
   echo "output: $output"
   echo "status: $status"
@@ -972,14 +972,14 @@ teardown() {
   assert_success
   assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/https.letsencrypt.tmpl)"
 
-  run docker run --rm --cidfile /tmp/cid-file-2 '--label=openresty.domains=python2.example.com _' '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=openresty.letsencrypt=true --label=com.dokku.app-name=python2 --label=com.dokku.process-type=web --name "${TEST_CONTAINER_NAME}_2" -d traefik/whoami -port=:5000
+  run docker run --rm --cidfile /tmp/cid-file-2 '--label=openresty.domains=python2.example.com _' '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=openresty.letsencrypt=true --label=com.dokku.app-name=python2 --label=com.dokku.process-type=web --name "${TEST_CONTAINER_NAME}_2" -d traefik/whoami -port=5000
   echo "output: $output"
   echo "status: $status"
   assert_success
 
   sleep 3
 
-  IP_ADDRESS_2="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "${TEST_CONTAINER_NAME}_2")"
+  IP_ADDRESS_2="$(get_container_ip "${TEST_CONTAINER_NAME}_2")"
   run echo "$IP_ADDRESS_2"
   echo "output: $output"
   echo "status: $status"
@@ -990,6 +990,16 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_output_cr "$(sed -e "s/VAR_IP_ADDRESS_1/$IP_ADDRESS/" -e "s/VAR_IP_ADDRESS_2/$IP_ADDRESS_2/" fixtures/https.letsencrypt-no-default.tmpl)"
+}
+
+get_container_ip() {
+  local container="$1"
+  local network
+  network="$(docker container inspect --format='{{index .Config.Labels "openresty.initial-network"}}' "$container")"
+  if [[ -z "$network" || "$network" == "<no value>" ]]; then
+    network="${OPENRESTY_DEFAULT_NETWORK:-bridge}"
+  fi
+  docker container inspect --format="{{(index .NetworkSettings.Networks \"$network\").IPAddress}}" "$container"
 }
 
 assert_equal() {

--- a/test.bats
+++ b/test.bats
@@ -478,6 +478,191 @@ teardown() {
   assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/http-allowed-ips-source-xff-basic-auth-satisfy-any.tmpl)"
 }
 
+@test "[start] http route" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --platform linux/amd64 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS_WEB="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS_API="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "${TEST_CONTAINER_NAME}_2")"
+  run echo "web=$IP_ADDRESS_WEB api=$IP_ADDRESS_API"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed -e "s/VAR_IP_ADDRESS_WEB/$IP_ADDRESS_WEB/" -e "s/VAR_IP_ADDRESS_API/$IP_ADDRESS_API/" fixtures/http-route.tmpl)"
+}
+
+@test "[start] http route strip-prefix" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --platform linux/amd64 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.0.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS_WEB="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS_API="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "${TEST_CONTAINER_NAME}_2")"
+  run echo "web=$IP_ADDRESS_WEB api=$IP_ADDRESS_API"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed -e "s/VAR_IP_ADDRESS_WEB/$IP_ADDRESS_WEB/" -e "s/VAR_IP_ADDRESS_API/$IP_ADDRESS_API/" fixtures/http-route-strip-prefix.tmpl)"
+}
+
+@test "[start] http route multiple" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file-2 --platform linux/amd64 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.1.path-prefix=/internal --label=openresty.route.1.port=5001 --label=openresty.route.1.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS_WEB="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS_API="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "${TEST_CONTAINER_NAME}_2")"
+  run echo "web=$IP_ADDRESS_WEB api=$IP_ADDRESS_API"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed -e "s/VAR_IP_ADDRESS_WEB/$IP_ADDRESS_WEB/" -e "s/VAR_IP_ADDRESS_API/$IP_ADDRESS_API/" fixtures/http-route-multiple.tmpl)"
+}
+
+@test "[start] https cert route" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container exec openresty-docker-proxy cp /etc/ssl/resty-auto-ssl-fallback.key /etc/nginx/ssl/python-server.key
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container exec openresty-docker-proxy cp /etc/ssl/resty-auto-ssl-fallback.crt /etc/nginx/ssl/python-server.crt
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm --cidfile /tmp/cid-file --platform linux/amd64 --label=openresty.domains=python.example.com '--label=openresty.port-mapping=http:80:5000 https:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm --cidfile /tmp/cid-file-2 --platform linux/amd64 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" -d dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS_WEB="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS_API="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "${TEST_CONTAINER_NAME}_2")"
+  run echo "web=$IP_ADDRESS_WEB api=$IP_ADDRESS_API"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed -e "s/VAR_IP_ADDRESS_WEB/$IP_ADDRESS_WEB/" -e "s/VAR_IP_ADDRESS_API/$IP_ADDRESS_API/" fixtures/https-route.cert.tmpl)"
+}
+
 @test "[unit] basic-auth lua module" {
   run docker image build -t openresty-docker-proxy:latest .
   echo "output: $output"


### PR DESCRIPTION
Non-web containers can now declare `openresty.route.<n>.path-prefix`, `openresty.route.<n>.port`, and optional `openresty.route.<n>.strip-prefix` labels to route a path prefix on the app's domains to a non-web Procfile process. For each labeled route, the http template emits an upstream pointing at the non-web container's IPs at the labeled port and a `location <path-prefix>` block inside every `server { }` block produced for the web container's domains. 

The route locations inherit the app's WebSocket headers, proxy buffer/timeout settings, and access controls (`basic-auth`, `allowed-ips`, `access-satisfy`) so they cannot become an authentication bypass, and they are only rendered in the proxy server block (not the http to https redirect block) so TLS is not bypassed.

`strip-prefix=true` renders `proxy_pass http://<upstream>/;` so the matched prefix is dropped before forwarding, matching the trailing-slash convention nginx uses.

Containers without `openresty.route.*` labels render identically to before. This unblocks dokku/dokku#8726, which will start emitting these labels from `openresty-vhosts` once this image releases.

A `openresty` and `openresty-opm` bump to `1.29.2.5-1~jammy1` restores reproducible builds after upstream removed the pinned `1.29.2.3` jammy packages from the arm64 repo.

Closes #137.