### PR TITLE
fix: skip stopped containers when rendering routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ The upstream port on the non-`web` container that requests matching `openresty.r
 
 > default: `false`
 
-When `true`, the matched `path-prefix` is stripped from the request before it is forwarded upstream (nginx renders `proxy_pass http://<upstream>/;` with a trailing slash). Use this when the upstream process is written assuming it is mounted at root (so it sees `/users/42` instead of `/api/v0/users/42`). When `false` or unset, the upstream sees the full original request path.
+When `true`, the matched `path-prefix` is stripped from the request before it is forwarded upstream. The sidecar renders an explicit `rewrite ^<path-prefix>/?(.*)$ /$1 break;` ahead of `proxy_pass` so the upstream sees `/users/42` instead of `/api/v0/users/42`. The rewrite form is used in place of the trailing-slash `proxy_pass http://<upstream>/;` style because that earlier style produced a `//` upstream URI which Go's `net/http` answers with a 301 redirect. When `false` or unset, the upstream sees the full original request path.
 
 #### `openresty.send-timeout`
 

--- a/templates/http.conf.tmpl
+++ b/templates/http.conf.tmpl
@@ -15,7 +15,7 @@
 # default_pagesize: {{ env "OPENRESTY_OS_PAGESIZE" }}
 {{ end }}
 
-{{ range $app, $appContainers := groupByLabel $ $app_label }}
+{{ range $app, $appContainers := groupByLabel (where $ "State.Running" true) $app_label }}
 
 {{ $all_app_containers := dict }}
 {{ range $process_type, $containers := groupByLabel $appContainers $process_label }}

--- a/test.bats
+++ b/test.bats
@@ -14,6 +14,10 @@ setup() {
     docker container rm -f "$(cat /tmp/cid-file-2)" || true
     rm /tmp/cid-file-2
   fi
+  if [[ -f "/tmp/cid-file-3" ]]; then
+    docker container rm -f "$(cat /tmp/cid-file-3)" || true
+    rm /tmp/cid-file-3
+  fi
 }
 
 teardown() {
@@ -26,6 +30,10 @@ teardown() {
   if [[ -f "/tmp/cid-file-2" ]]; then
     docker container rm -f "$(cat /tmp/cid-file-2)" || true
     rm /tmp/cid-file-2
+  fi
+  if [[ -f "/tmp/cid-file-3" ]]; then
+    docker container rm -f "$(cat /tmp/cid-file-3)" || true
+    rm /tmp/cid-file-3
   fi
 }
 
@@ -602,6 +610,65 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_output_cr "$(sed -e "s/VAR_IP_ADDRESS_WEB/$IP_ADDRESS_WEB/" -e "s/VAR_IP_ADDRESS_API/$IP_ADDRESS_API/" fixtures/http-route-multiple.tmpl)"
+}
+
+@test "[start] http route strip-prefix label flip on recreated container" {
+  run docker image build -t openresty-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name openresty-docker-proxy openresty-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --label=openresty.domains=python.example.com --label=openresty.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" traefik/whoami -port=5000
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # Start the original api container WITHOUT --rm so it lingers as `exited`
+  # after we stop it. This mirrors dokku's scheduler-deploy retire flow.
+  run docker run -d --cidfile /tmp/cid-file-2 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_2" traefik/whoami -port=5001
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker container stop "$(cat /tmp/cid-file-2)"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # Start the replacement api container with the strip-prefix label added.
+  # The previous container still exists in `docker ps -a` (exited) until the
+  # teardown removes it, exactly as it would during a dokku rolling deploy.
+  run docker run -d --cidfile /tmp/cid-file-3 --label=openresty.port-mapping=http:80:5001 --label=openresty.route.0.path-prefix=/api/v0 --label=openresty.route.0.port=5001 --label=openresty.route.0.strip-prefix=true --label=com.dokku.app-name=python --label=com.dokku.process-type=api --name "${TEST_CONTAINER_NAME}_3" traefik/whoami -port=5001
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 3
+
+  run docker logs openresty-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS_WEB="$(get_container_ip "$TEST_CONTAINER_NAME")"
+  IP_ADDRESS_API="$(get_container_ip "${TEST_CONTAINER_NAME}_3")"
+  run echo "web=$IP_ADDRESS_WEB api=$IP_ADDRESS_API"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec openresty-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed -e "s/VAR_IP_ADDRESS_WEB/$IP_ADDRESS_WEB/" -e "s/VAR_IP_ADDRESS_API/$IP_ADDRESS_API/" fixtures/http-route-strip-prefix.tmpl)"
 }
 
 @test "[start] https cert route" {


### PR DESCRIPTION
## Summary

docker-gen lists containers with `All:true`, so an api container that has been stopped (but not removed) by dokku's rolling deploy continues to appear in the template's input. The route-discovery loop picks the first container in each process group via `index 0`, and the upstream block iterates every container in the group, so a lingering exited container could either supply stale labels (masking a newly added `strip-prefix`) or contribute a stale `server <ip>:<port>;` line to the upstream list - which is what dokku CI was seeing as the "Contents did not change. Skipping notification" symptom on the strip-prefix toggle path described in #141.

Filtering the input slice to `State.Running` containers before grouping means only currently-running containers contribute to route labels, upstream servers, and web-server settings. The route fixtures already only describe the running container's state, so existing tests are unaffected. A new bats test stops one api container and starts a replacement with `strip-prefix=true`, then asserts the rendered sites.conf matches the existing `fixtures/http-route-strip-prefix.tmpl`; without the fix the upstream block includes a `server :5001;` line for the stopped container and the assertion fails.

The README's `openresty.route.<n>.strip-prefix` section is also refreshed - it still described the pre-ace42b3 `proxy_pass http://<upstream>/;` rendering rather than the current `rewrite ... break;` form.

Closes #141.